### PR TITLE
Improve print_tree(::Dict)

### DIFF
--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -50,8 +50,9 @@ children(x::Expr) = x.args
 # create a special iterator that `children` on `Associative` returns.
 # Even better, iteration over associatives should return pairs.
 
-printnode(io::IO, kv::Pair{K,V}) where {K,V} = printnode(io,kv[1])
-children(kv::Pair{K,V}) where {K,V} = (kv[2],)
+children(d::Dict) = [p for p in d]
+children(kv::Pair) = children(kv[2])
+printnode(io::IO, kv::Pair) = isempty(children(kv[2])) ? print(io,"$(kv[1]): $(kv[2])") : print(io,"$(kv[1]):")
 
 printnode(io::IO, d::Dict{K,V}) where {K,V} = print(io, Dict{K,V})
 printnode(io::IO, d::Vector{T}) where {T} = print(io, Vector{T})

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -52,7 +52,7 @@ children(x::Expr) = x.args
 
 children(d::Dict) = [p for p in d]
 children(kv::Pair) = children(kv[2])
-printnode(io::IO, kv::Pair) = isempty(children(kv[2])) ? print(io,"$(kv[1]): $(kv[2])") : print(io,"$(kv[1]):")
+printnode(io::IO, kv::Pair) = isempty(children(kv[2])) ? print(io,"$(kv[1]): $(kv[2])") : print(io,"$(kv[1]): $(typeof(kv[2]))")
 
 printnode(io::IO, d::Dict{K,V}) where {K,V} = print(io, Dict{K,V})
 printnode(io::IO, d::Vector{T}) where {T} = print(io, Vector{T})


### PR DESCRIPTION
Beauty is in the eye of the beholder, but I think this looks a little better.

What do you think?

```julia
julia> d = Dict(:a => 2,:d => Dict(:b => 4,:c => "Hello"),:e => 5.0)
Dict{Symbol,Any} with 3 entries:
  :a => 2
  :d => Dict{Symbol,Any}(:b=>4,:c=>"Hello")
  :e => 5.0
```

### Before

```julia
julia> print_tree(d)
Dict{Symbol,Any}
├─ 2
├─ Dict{Symbol,Any}
│  ├─ 4
│  └─ "Hello"
└─ 5.0
```

### After

```julia
julia> print_tree(d)
Dict{Symbol,Any}
├─ a: 2
├─ d:
│  ├─ b: 4
│  └─ c: Hello
└─ e: 5.0
```