### PR TITLE
Some minor code cleanup

### DIFF
--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -1,3 +1,9 @@
+"""
+This package is intended to provide an abstract interface for working
+with tree structures.
+Though the package itself is not particularly sophisticated, it defines
+the interface that can be used by other packages to talk about trees.
+"""
 module AbstractTrees
 
 export print_tree, TreeCharSet, TreeIterator, Leaves, PostOrderDFS, Tree,
@@ -13,11 +19,6 @@ abstract type AbstractShadowTree end
 
 include("traits.jl")
 include("implicitstacks.jl")
-
-# This package is intended to provide an abstract interface for working
-# with tree structures.
-# Though the package itself is not particularly sophisticated, it defines
-# the interface that can be used by other packages to talk about trees.
 
 """
     children(x)

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -27,6 +27,10 @@ Return the immediate children of node `x`. You should specialize this method
 for custom tree structures. It should return an iterable object for which an
 appropriate implementation of `Base.pairs` is available.
 
+The default behavior is to assume that if an object is iterable, iterating over
+it gives its children. If an object is not iterable, assume it does not have
+children.
+
 # Example
 
 ```
@@ -37,16 +41,8 @@ end
 AbstractTrees.children(node::MyNode) = node.children
 ```
 """
-function children(x)
-    # By default assume that if an object is iterable, its iteration gives the
-    # children. If an object is not iterable, assume it does not have children by
-    # default.
-    if Base.isiterable(typeof(x)) && !isa(x, Integer) && !isa(x, Char) && !isa(x, Task)
-        return x
-    else
-        return ()
-    end
-end
+children(x) = Base.isiterable(typeof(x)) ? x : ()
+
 has_children(x) = children(x) !== ()
 
 """
@@ -70,7 +66,10 @@ printnode(io::IO, node) = show(IOContext(io, :compact => true), node)
 
 ## Special cases
 
-# Don't consider strings or reals tree-iterable in general
+# Types which are iterable but shouldn't be considered tree-iterable
+children(x::Integer) = ()
+children(x::Char) = ()
+children(x::Task) = ()
 children(x::AbstractString) = ()
 children(x::Real) = ()
 

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -87,8 +87,6 @@ children(kv::Pair{K,V}) where {K,V} = (kv[2],)
 printnode(io::IO, d::Dict{K,V}) where {K,V} = print(io, Dict{K,V})
 printnode(io::IO, d::Vector{T}) where {T} = print(io, Vector{T})
 
-# Node equality predicate
-nodeequal(a, b) = a === b
 
 # Utilities
 

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -67,11 +67,10 @@ printnode(io::IO, node) = show(IOContext(io, :compact => true), node)
 ## Special cases
 
 # Types which are iterable but shouldn't be considered tree-iterable
-children(x::Integer) = ()
+children(x::Number) = ()
 children(x::Char) = ()
 children(x::Task) = ()
 children(x::AbstractString) = ()
-children(x::Real) = ()
 
 # Define this here, there isn't really a good canonical package to define this
 # elsewhere


### PR DESCRIPTION
* Move description of module from comment into an actual docstring.
* Remove `nodeequal` function, which was not documented or used anywhere.
* Add separate `children` methods for `Integer`, `Char`, and `Task` instead of checking the type of the argument in the default method.
  * Remove redundant `Integer` and `Real` methods (`Integer <: Real`), replace with `Number` which also covers the `Complex` case and other user-defined subtypes.