### PR TITLE
Minor changes for builtin types

### DIFF
--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -50,28 +50,7 @@ include("implicitstacks.jl")
 include("printing.jl")
 include("indexing.jl")
 include("iteration.jl")
-
-
-## Special cases
-
-# Types which are iterable but shouldn't be considered tree-iterable
-children(x::Number) = ()
-children(x::Char) = ()
-children(x::Task) = ()
-children(x::AbstractString) = ()
-
-# Define this here, there isn't really a good canonical package to define this
-# elsewhere
-children(x::Expr) = x.args
-
-# For AbstractDicts
-
-printnode(io::IO, kv::Pair{K,V}) where {K,V} = printnode(io,kv[1])
-children(kv::Pair{K,V}) where {K,V} = (kv[2],)
-
-# For potentially-large containers, just show the type
-
-printnode(io::IO, ::T) where T <: Union{AbstractArray, AbstractDict} = print(io, T)
+include("builtins.jl")
 
 
 end # module

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -1,0 +1,21 @@
+# Tree API implementations for builtin types
+
+
+# Types which are iterable but shouldn't be considered tree-iterable
+children(x::Number) = ()
+children(x::Char) = ()
+children(x::Task) = ()
+children(x::AbstractString) = ()
+
+
+# Expr
+children(x::Expr) = x.args
+
+
+# AbstractDict
+printnode(io::IO, kv::Pair{K,V}) where {K,V} = printnode(io,kv[1])
+children(kv::Pair{K,V}) where {K,V} = (kv[2],)
+
+
+# For potentially-large containers, just show the type
+printnode(io::IO, ::T) where T <: Union{AbstractArray, AbstractDict} = print(io, T)

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -11,6 +11,12 @@ children(x::AbstractString) = ()
 # Expr
 children(x::Expr) = x.args
 
+function printnode(io::IO, x::Expr)
+	print(io, "Expr(")
+	show(io, x.head)
+	print(io, ")")
+end
+
 
 # AbstractDict
 printnode(io::IO, kv::Pair{K,V}) where {K,V} = printnode(io,kv[1])

--- a/test/builtins.jl
+++ b/test/builtins.jl
@@ -15,3 +15,14 @@
     tree2 = Any[Any[1,2],Any[3,4]]
     @test collect(PreOrderDFS(tree2)) == Any[tree2,Any[1,2],1,2,Any[3,4],3,4]
 end
+
+
+@testset "Expr" begin
+    expr = :(foo(x^2 + 3))
+
+    @test children(expr) == expr.args
+
+    @test repr_tree(expr) == "Expr(:call)\n├─ :foo\n└─ Expr(:call)\n   ├─ :+\n   ├─ Expr(:call)\n   │  ├─ :^\n   │  ├─ :x\n   │  └─ 2\n   └─ 3\n"
+
+    @test collect(Leaves(expr)) == [:foo, :+, :^, :x, 2, 3]
+end


### PR DESCRIPTION
Move implementations for builtin types to their own source file, add `print_node` implementation and tests for `Base.Expr`.