### PR TITLE
Misc changes to tree printing

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,4 +25,6 @@ AbstractTrees.printnode
 AbstractTrees.siblinglinks
 treemap
 treemap!
+AbstractTrees.DEFAULT_CHARSET
+AbstractTrees.ASCII_CHARSET
 ```

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -66,6 +66,23 @@ printnode(io::IO, node) = show(IOContext(io, :compact => true), node)
 
 
 """
+    repr_node(node; context=nothing)
+
+Get the string representation of a node using [`printnode`](@ref). This works
+analagously to `Base.repr`.
+
+`context` is an `IO` or `IOContext` object whose attributes are used for the
+I/O stream passed to `printnode`.
+"""
+function repr_node(node; context=nothing)
+    buf = IOBuffer()
+    io = context === nothing ? buf : IOContext(buf, context)
+    printnode(io, node)
+    return String(take!(buf))
+end
+
+
+"""
     TreeCharSet
 
 Set of characters (or strings) used to pretty-print tree branches in

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -62,7 +62,7 @@ end
 AbstractTrees.printnode(io::IO, node::MyNode) = print(io, "MyNode(\$(node.data))")
 ```
 """
-printnode(io::IO, node) = show(IOContext(io, :compact => true), node)
+printnode(io::IO, node) = show(IOContext(io, :compact => true, :limit => true), node)
 
 
 """

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -96,9 +96,15 @@ struct TreeCharSet
     trunc
 end
 
-# Default charset
-TreeCharSet() = TreeCharSet('├','└','│','─','⋮')
-TreeCharSet(mid, term, skip, dash) = TreeCharSet(mid, term, skip, dash, '⋮')
+"""Default `charset` argument used by [`print_tree`](@ref)."""
+const DEFAULT_CHARSET = TreeCharSet('├', '└', '│', '─', '⋮')
+"""Charset using only ASCII characters."""
+const ASCII_CHARSET = TreeCharSet("+", "\\", "|", "--", "...")
+
+function TreeCharSet()
+    Base.depwarn("The 0-argument constructor of TreeCharSet is deprecated, use AbstractTrees.DEFAULT_CHARSET instead.", :TreeCharSet)
+    return DEFAULT_CHARSET
+end
 
 
 """
@@ -116,7 +122,7 @@ function print_prefix(io::IO, depth::Int, charset::TreeCharSet, active_levels)
 end
 
 function _print_tree(printnode::Function, io::IO, tree; maxdepth = 5, indicate_truncation = true,
-                     depth = 0, active_levels = Int[], charset = TreeCharSet(), withinds = false,
+                     depth = 0, active_levels = Int[], charset = DEFAULT_CHARSET, withinds = false,
                      inds = [], from = nothing, to = nothing, roottree = tree)
     nodebuf = IOBuffer()
     isa(io, IOContext) && (nodebuf = IOContext(nodebuf, io))

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -52,7 +52,7 @@ AbstractTrees.children(::SingleChildInfiniteDepth) = (SingleChildInfiniteDepth()
     #       └─ 3
     #
 
-    truncation_char = AbstractTrees.TreeCharSet().trunc
+    truncation_char = AbstractTrees.DEFAULT_CHARSET.trunc
 
     for maxdepth in [3,5,8]
         ptxt = repr_tree(Num(0), maxdepth=maxdepth)


### PR DESCRIPTION
* Added/improved docstrings for printing-related functions and types.
* Add `repr_node()` function, similar to `repr_tree()`.
* Add `:limit => true` to `IOContext` used in default `printnode()` implementation.
* Default value for `charset` argument to `print_tree()` is now defined in the `DEFAULT_CHARSET`constant/global rather than 
  being returned from the no-argument constructor.
* Defined `ASCII_CHARSET` constant for `TreeCharSet` using only ASCII characters.
* Improvements to printing truncation test.