### PR TITLE
Change print_tree() maxdepth positional argument to keyword argument

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,7 +1,7 @@
 """
-    print_tree(tree, maxdepth=5; kwargs...)
-    print_tree(io, tree, maxdepth=5; kwargs...)
-    print_tree(f::Function, io, tree, maxdepth=5; kwargs...)
+    print_tree(tree; kwargs...)
+    print_tree(io::IO, tree; kwargs...)
+    print_tree(f::Function, io::IO, tree; kwargs...)
 
 # Usage
 Prints an ASCII formatted representation of the `tree` to the given `io` object.
@@ -86,7 +86,7 @@ function print_prefix(io, depth, charset, active_levels)
     end
 end
 
-function _print_tree(printnode::Function, io::IO, tree, maxdepth = 5; indicate_truncation = true,
+function _print_tree(printnode::Function, io::IO, tree; maxdepth = 5, indicate_truncation = true,
                      depth = 0, active_levels = Int[], charset = TreeCharSet(), withinds = false,
                      inds = [], from = nothing, to = nothing, roottree = tree)
     nodebuf = IOBuffer()
@@ -121,7 +121,7 @@ function _print_tree(printnode::Function, io::IO, tree, maxdepth = 5; indicate_t
                     child_active_levels = push!(copy(active_levels), depth)
                 end
                 print(io, charset.dash, ' ')
-                print_tree(printnode, io, child, maxdepth;
+                print_tree(printnode, io, child; maxdepth=maxdepth,
                 indicate_truncation=indicate_truncation, depth = depth + 1,
                 active_levels = child_active_levels, charset = charset, withinds=withinds,
                 inds = withinds ? [inds; ind] : [], roottree = roottree)
@@ -134,7 +134,14 @@ function _print_tree(printnode::Function, io::IO, tree, maxdepth = 5; indicate_t
         end
     end
 end
-print_tree(f::Function, io::IO, tree, args...; kwargs...) = _print_tree(f, io, tree, args...; kwargs...)
+
+print_tree(f::Function, io::IO, tree; kwargs...) = _print_tree(f, io, tree; kwargs...)
+
+function print_tree(f::Function, io::IO, tree, maxdepth; kwargs...)
+    Base.depwarn("Passing maxdepth as a positional argument is deprecated, use as a keyword argument instead.", :print_tree)
+    print_tree(f, io, tree; maxdepth=maxdepth, kwargs...)
+end
+
 print_tree(io::IO, tree, args...; kwargs...) = print_tree(printnode, io, tree, args...; kwargs...)
 print_tree(tree, args...; kwargs...) = print_tree(stdout::IO, tree, args...; kwargs...)
 

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -32,7 +32,7 @@ AbstractTrees.children(::SingleChildInfiniteDepth) = (SingleChildInfiniteDepth()
     #
 
     for maxdepth in [3,5,8]
-        ptxt = repr_tree(Num(0), maxdepth)
+        ptxt = repr_tree(Num(0), maxdepth=maxdepth)
 
         n1  = sum([1 for c in ptxt if c=="$(maxdepth-1)"[1]])
         n2  = sum([1 for c in ptxt if c=="$maxdepth"[1]])
@@ -68,12 +68,30 @@ AbstractTrees.children(::SingleChildInfiniteDepth) = (SingleChildInfiniteDepth()
     @test numlines == 7 # 1 (head node) + 5 (default depth) + 1 (truncation char)
 
     # test correct number of lines printed 2
-    ptxt = repr_tree(SingleChildInfiniteDepth(), 3)
+    ptxt = repr_tree(SingleChildInfiniteDepth(), maxdepth=3)
     numlines = sum([1 for c in split(ptxt, '\n') if ~isempty(strip(c))])
     @test numlines == 5 # 1 (head node) + 3 (depth) + 1 (truncation char)
 
     # test correct number of lines printed 3
-    ptxt = repr_tree(SingleChildInfiniteDepth(), 3, indicate_truncation=false)
+    ptxt = repr_tree(SingleChildInfiniteDepth(), maxdepth=3, indicate_truncation=false)
     numlines = sum([1 for c in split(ptxt, '\n') if ~isempty(strip(c))])
     @test numlines == 4 # 1 (head node) + 3 (depth)
+end
+
+
+@testset "print_tree maxdepth as positional argument" begin
+    tree = Num(0)
+
+    @test_deprecated print_tree(devnull, tree, 3)
+    @test_deprecated print_tree(AbstractTrees.printnode, devnull, tree, 3)
+
+    buf = IOBuffer()
+
+    for maxdepth in [3, 5, 8]
+        print_tree(buf, tree, maxdepth)
+        str = String(take!(buf))
+        truncate(buf, 0)
+
+        @test str == repr_tree(tree, maxdepth=maxdepth)
+    end
 end


### PR DESCRIPTION
Makes sense to have this as a keyword argument along with the other options. Also having multiple methods with different numbers of positional arguments, all with an optional positional argument on the end, is sort of iffy even if the types of the `f` and `io` args prevent there from being any actual ambiguity in the signatures.

Added a method accepting the old signature for backwards compatibility which prints a deprecation warning.