### PR TITLE
Add support for Core.Compiler.Timings

### DIFF
--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -25,3 +25,9 @@ children(kv::Pair{K,V}) where {K,V} = (kv[2],)
 
 # For potentially-large containers, just show the type
 printnode(io::IO, ::T) where T <: Union{AbstractArray, AbstractDict} = print(io, T)
+
+if isdefined(Core.Compiler, :Timings)
+	children(t::Core.Compiler.Timings.Timing) = t.children
+	printnode(io::IO, t::Core.Compiler.Timings.Timing) = print(io, t.time/10^6, "ms: ", t.mi_info)
+	nodetype(t::Core.Compiler.Timings.Timing) = Core.Compiler.Timings.Timing
+end

--- a/test/builtins.jl
+++ b/test/builtins.jl
@@ -1,5 +1,7 @@
 # Test implementation for builtin types
-
+using AbstractTrees
+using AbstractTrees: repr_tree
+using Test
 
 @testset "Array" begin
     tree = Any[1,Any[2,3]]
@@ -25,4 +27,62 @@ end
     @test repr_tree(expr) == "Expr(:call)\n├─ :foo\n└─ Expr(:call)\n   ├─ :+\n   ├─ Expr(:call)\n   │  ├─ :^\n   │  ├─ :x\n   │  └─ 2\n   └─ 3\n"
 
     @test collect(Leaves(expr)) == [:foo, :+, :^, :x, 2, 3]
+end
+
+if Base.VERSION >= v"1.6.0-DEV.1594"
+    # Much of this is taken from julia/test/compiler/inference.jl
+    @testset "Core.Compiler.Timings" begin
+        matches(rex, str) = match(rex, str) !== nothing
+        function time_inference(f)
+            Core.Compiler.Timings.reset_timings()
+            Core.Compiler.__set_measure_typeinf(true)
+            f()
+            Core.Compiler.__set_measure_typeinf(false)
+            Core.Compiler.Timings.close_current_timer()
+            return Core.Compiler.Timings._timings[1]
+        end
+        function eval_module()
+            @eval module AbstractTreesTestInferenceTiming
+                i(x) = x+5
+                i2(x) = x+2
+                h(a::Array) = i2(a[1]::Integer) + i(a[1]::Integer) + 2
+                g(y::Integer, x) = h(Any[y]) + Int(x)
+            end
+        end
+        # Define and make sure all "underlying" functions are compiled
+        eval_module()
+        AbstractTreesTestInferenceTiming.g(2, 3.0)
+        # Now do the real test with a freshly-evaluated module
+        eval_module()
+        tinf = time_inference() do
+            @eval AbstractTreesTestInferenceTiming.g(2, 3.0)
+        end
+        io = IOBuffer()
+        print_tree(io, tinf)
+        strs = split(chomp(String(take!(io))), '\n')
+        rexf = "[0-9]*\\.?[0-9]*"
+        thismod = "$(@__MODULE__)"
+        @test any(strs) do str
+            matches(Regex("$(rexf)ms: InferenceFrameInfo for Core\\.Compiler\\.Timings\\.ROOT\\(\\)"), str)
+        end
+        @test any(strs) do str
+            matches(Regex("├─ $(rexf)ms: InferenceFrameInfo for $(thismod)\\.AbstractTreesTestInferenceTiming\\.g\\(::$Int, ::Float64\\)"), str)
+        end
+        @test any(strs) do str
+            matches(Regex("│  └─ $(rexf)ms: InferenceFrameInfo for $(thismod)\\.AbstractTreesTestInferenceTiming\\.h\\(::Vector{Any}\\)"), str)
+        end
+        @test any(strs) do str
+            matches(Regex("├─ $(rexf)ms: InferenceFrameInfo for $(thismod)\\.AbstractTreesTestInferenceTiming\\.i2\\(::Integer\\)"), str)
+        end
+        @test any(strs) do str
+            matches(Regex("└─ $(rexf)ms: InferenceFrameInfo for $(thismod)\\.AbstractTreesTestInferenceTiming\\.i\\(::Integer\\)"), str)
+        end
+        # These two do not have the pipe characters because we aren't sure which will be last
+        @test any(strs) do str
+            matches(Regex("$(rexf)ms: InferenceFrameInfo for $(thismod)\\.AbstractTreesTestInferenceTiming\\.i2\\(::$Int\\)"), str)
+        end
+        @test any(strs) do str
+            matches(Regex("$(rexf)ms: InferenceFrameInfo for $(thismod)\\.AbstractTreesTestInferenceTiming\\.i\\(::$Int\\)"), str)
+        end
+    end
 end


### PR DESCRIPTION
Julia 1.6 will allow collection of an object recording performance information about type-inference on an entire call tree. This PR adds support for displaying this object.

I'm deliberately not adding a test yet because I'm about to submit a Julia PR (UPDATE: https://github.com/JuliaLang/julia/pull/38596) adding pretty-printing for `Core.Compiler.Timings.InferenceFrameInfo`, and if that's accepted it will modify the ouput. But that PR will reference AbstractTrees as a way to get more info about a `Core.Compiler.Timings.Timing` object, so I'm filing this now as a placeholder.