### PR TITLE
Update Documenter version for docs building

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.26"


### PR DESCRIPTION
Fixes [error](https://github.com/JuliaDocs/Documenter.jl/pull/1510) in handling doctests with empty output.