### PR TITLE
Additional API functions for children and subtrees

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,12 +10,20 @@ AbstractTrees.ParentLinks
 AbstractTrees.SiblingLinks
 AbstractTrees.StoredParents
 AbstractTrees.StoredSiblings
+childcount
 children
+intree
+ischild
+isdescendant
+isleaf
 AbstractTrees.nodetype
 AbstractTrees.parentlinks
 AbstractTrees.siblinglinks
+treebreadth
+treeheight
 treemap
 treemap!
+treesize
 ```
 
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,12 +10,10 @@ AbstractTrees.ParentLinks
 AbstractTrees.SiblingLinks
 AbstractTrees.StoredParents
 AbstractTrees.StoredSiblings
-childcount
 children
 intree
 ischild
 isdescendant
-isleaf
 AbstractTrees.nodetype
 AbstractTrees.parentlinks
 AbstractTrees.siblinglinks

--- a/docs/src/implementing.md
+++ b/docs/src/implementing.md
@@ -63,6 +63,36 @@ tree = MyNode(1, [
 ```
 
 
+## Optional functions
+
+These functions have default implementations that depend only on the output of `children`, but may
+have suboptimal performance that can be improved by adding a custom method for your type.
+
+
+### children-related functions
+
+If the `children` method for your type involves a non-trivial amount of computation (e.g. if the
+returned child objects need to be created with each call instead of being explicitly stored in the
+parent as in the example above) providing your own implementation of these functions may
+significantly reduce overhead:
+
+* [`childcount`](@ref)
+* [`isleaf`](@ref)
+* [`ischild`](@ref)
+
+
+### Subtree-related
+
+The following functions recurse through a node's entire subtree by default, which should be avoided
+if possible:
+
+* [`intree`](@ref)
+* [`isdescendant`](@ref)
+* [`treebreadth`](@ref)
+* [`treesize`](@ref)
+* [`treeheight`](@ref)
+
+
 ## Type traits
 
 * [`AbstractTrees.nodetype(tree)`](@ref) can be defined to make iteration inferable.

--- a/docs/src/implementing.md
+++ b/docs/src/implementing.md
@@ -76,8 +76,6 @@ returned child objects need to be created with each call instead of being explic
 parent as in the example above) providing your own implementation of these functions may
 significantly reduce overhead:
 
-* [`childcount`](@ref)
-* [`isleaf`](@ref)
 * [`ischild`](@ref)
 
 

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -31,8 +31,6 @@ it gives its children. Non-iterable types are treated as leaf nodes.
 """
 children(x) = Base.isiterable(typeof(x)) ? x : ()
 
-has_children(x) = children(x) !== ()
-
 
 include("traits.jl")
 include("implicitstacks.jl")

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -6,7 +6,7 @@ the interface that can be used by other packages to talk about trees.
 """
 module AbstractTrees
 
-export children, childcount, isleaf, ischild, intree, isdescendant, treesize, treebreadth, treeheight
+export children, ischild, intree, isdescendant, treesize, treebreadth, treeheight
 export print_tree, TreeCharSet
 export TreeIterator, Leaves, PostOrderDFS, PreOrderDFS, StatelessBFS
 export Tree, ShadowTree, AnnotationNode, treemap, treemap!

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -18,21 +18,8 @@ using Base: SizeUnknown, EltypeUnknown
 abstract type AbstractShadowTree end
 
 
-"""
-    children(x)
-
-Get the immediate children of node `x`.
-
-This is the primary function that needs to be implemented for custom tree types. It should return an
-iterable object for which an appropriate implementation of `Base.pairs` is available.
-
-The default behavior is to assume that if an object is iterable, iterating over
-it gives its children. Non-iterable types are treated as leaf nodes.
-"""
-children(x) = Base.isiterable(typeof(x)) ? x : ()
-
-
 include("traits.jl")
+include("base.jl")
 include("implicitstacks.jl")
 include("printing.jl")
 include("indexing.jl")

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -6,9 +6,10 @@ the interface that can be used by other packages to talk about trees.
 """
 module AbstractTrees
 
-export print_tree, TreeCharSet, TreeIterator, Leaves, PostOrderDFS, Tree,
-    AnnotationNode, StatelessBFS, treemap, treemap!, PreOrderDFS,
-    ShadowTree, children
+export children, childcount, isleaf, ischild, intree, isdescendant, treesize, treebreadth, treeheight
+export print_tree, TreeCharSet
+export TreeIterator, Leaves, PostOrderDFS, PreOrderDFS, StatelessBFS
+export Tree, ShadowTree, AnnotationNode, treemap, treemap!
 
 import Base: getindex, setindex!, iterate, nextind, print, show,
     eltype, IteratorSize, IteratorEltype, length, push!, pop!

--- a/src/base.jl
+++ b/src/base.jl
@@ -19,12 +19,12 @@ children(node) = Base.isiterable(typeof(node)) ? node : ()
 """
     ischild(node1, node2)
 
-Check if `node2` is the parent of `node1`.
+Check if `node1` is a child of `node2`.
+
+By default this iterates through ``children(node2)``, so performance may be improved by adding a
+specialized method for given node type.
 """
 ischild(node1, node2) = any(node -> node === node1, children(node2))
-
-This is equivalent to `length(children(node))` but may be more effecient for certain types.
-"""
 
 
 #

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,7 +1,11 @@
-"""
-    children(x)
+#
+# children() and related functions
+#
 
-Get the immediate children of node `x`.
+"""
+    children(node)
+
+Get the immediate children of `node`.
 
 This is the primary function that needs to be implemented for custom tree types. It should return an
 iterable object for which an appropriate implementation of `Base.pairs` is available.
@@ -9,4 +13,92 @@ iterable object for which an appropriate implementation of `Base.pairs` is avail
 The default behavior is to assume that if an object is iterable, iterating over
 it gives its children. Non-iterable types are treated as leaf nodes.
 """
-children(x) = Base.isiterable(typeof(x)) ? x : ()
+children(node) = Base.isiterable(typeof(node)) ? node : ()
+
+
+"""
+    isleaf(node)
+
+Check if `node` is a leaf node - i.e. has no children.
+"""
+isleaf(node) = childcount(node) == 0
+
+
+"""
+    ischild(node1, node2)
+
+Check if `node2` is the parent of `node1`.
+"""
+ischild(node1, node2) = any(node -> node === node1, children(node2))
+
+
+"""
+    childcount(node)
+
+Get the count of a node's children.
+
+This is equivalent to `length(children(node))` but may be more effecient for certain types.
+"""
+childcount(node) = length(children(node))
+
+
+#
+# Subtree-related functions
+#
+
+"""
+    intree(node, root)
+
+Check if `node` is a member of the tree rooted at `root`.
+
+By default this traverses through the entire tree in search of `node`, and so may be slow if a
+more specialized method has not been implemented for the given tree type.
+
+See also: [`isdescendant`](@ref)
+"""
+intree(node, root) = any(n -> n === node, PreOrderDFS(root))
+
+"""
+    isdescendant(node1, node2)
+
+Check if `node1` is a descendant of `node2`. This isequivalent to checking whether `node1` is a
+member of the subtree rooted at `node2` (see [`intree`](@ref)) except that a node cannot be a
+descendant of itself.
+
+Internally this calls `intree(node1, node2)` and so may be slow if a specialized method of that
+function is not available.
+"""
+isdescendant(node1, node2) = node1 !== node2 && intree(node1, node2)
+
+
+"""
+    treesize(node)
+
+Get the size of the tree rooted at `node`.
+
+By default this recurses through all nodes in the tree and so may be slow if a more specialized
+method has not been implemented for the given type.
+"""
+treesize(node) = isleaf(node) ? 1 : 1 + mapreduce(treesize, +, children(node))
+
+
+"""
+    treebreadth(node)
+
+Get the number of leaves in the tree rooted at `node`. Leaf nodes have a breadth of one.
+
+By default this recurses through all nodes in the tree and so may be slow if a more specialized
+method has not been implemented for the given type.
+"""
+treebreadth(node) = isleaf(node) ? 1 : mapreduce(treebreadth, +, children(node))
+
+
+"""
+    treeheight(node)
+
+Get the maximum depth from `node` to any of its descendants. Leaf nodes have a height of zero.
+
+By default this recurses through all nodes in the tree and so may be slow if a more specialized
+method has not been implemented for the given type.
+"""
+treeheight(node) = isleaf(node) ? 0 : 1 + mapreduce(treeheight, max, children(node))

--- a/src/base.jl
+++ b/src/base.jl
@@ -17,29 +17,14 @@ children(node) = Base.isiterable(typeof(node)) ? node : ()
 
 
 """
-    isleaf(node)
-
-Check if `node` is a leaf node - i.e. has no children.
-"""
-isleaf(node) = childcount(node) == 0
-
-
-"""
     ischild(node1, node2)
 
 Check if `node2` is the parent of `node1`.
 """
 ischild(node1, node2) = any(node -> node === node1, children(node2))
 
-
-"""
-    childcount(node)
-
-Get the count of a node's children.
-
 This is equivalent to `length(children(node))` but may be more effecient for certain types.
 """
-childcount(node) = length(children(node))
 
 
 #
@@ -79,7 +64,7 @@ Get the size of the tree rooted at `node`.
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treesize(node) = isleaf(node) ? 1 : 1 + mapreduce(treesize, +, children(node))
+treesize(node) = 1 + mapreduce(treesize, +, children(node), init=0)
 
 
 """
@@ -90,7 +75,7 @@ Get the number of leaves in the tree rooted at `node`. Leaf nodes have a breadth
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treebreadth(node) = isleaf(node) ? 1 : mapreduce(treebreadth, +, children(node))
+treebreadth(node) = isempty(children(node)) ? 1 : mapreduce(treebreadth, +, children(node))
 
 
 """
@@ -101,4 +86,4 @@ Get the maximum depth from `node` to any of its descendants. Leaf nodes have a h
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treeheight(node) = isleaf(node) ? 0 : 1 + mapreduce(treeheight, max, children(node))
+treeheight(node) = isempty(children(node)) ? 0 : 1 + mapreduce(treeheight, max, children(node))

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,0 +1,12 @@
+"""
+    children(x)
+
+Get the immediate children of node `x`.
+
+This is the primary function that needs to be implemented for custom tree types. It should return an
+iterable object for which an appropriate implementation of `Base.pairs` is available.
+
+The default behavior is to assume that if an object is iterable, iterating over
+it gives its children. Non-iterable types are treated as leaf nodes.
+"""
+children(x) = Base.isiterable(typeof(x)) ? x : ()

--- a/test/builtins.jl
+++ b/test/builtins.jl
@@ -14,8 +14,52 @@ using Test
     @test collect(PostOrderDFS(tree)) == Any[1,2,3,Any[2,3],Any[1,Any[2,3]]]
     @test collect(StatelessBFS(tree)) == Any[Any[1,Any[2,3]],1,Any[2,3],2,3]
 
+    @test childcount(tree) == 2
+    @test !isleaf(tree)
+    @test treesize(tree) == 5
+    @test treebreadth(tree) == 3
+    @test treeheight(tree) == 2
+
+    @test ischild(1, tree)
+    @test !ischild(2, tree)
+    @test ischild(tree[2], tree)
+    @test !ischild(copy(tree[2]), tree)  # Should work on identity, not equality
+
+    @test isdescendant(1, tree)
+    @test isdescendant(2, tree)
+    @test !isdescendant(4, tree)
+    @test isdescendant(tree[2], tree)
+    @test !isdescendant(copy(tree[2]), tree)
+    @test !isdescendant(tree, tree)
+
+    @test intree(1, tree)
+    @test intree(2, tree)
+    @test !intree(4, tree)
+    @test intree(tree[2], tree)
+    @test !intree(copy(tree[2]), tree)
+    @test intree(tree, tree)
+
+
     tree2 = Any[Any[1,2],Any[3,4]]
     @test collect(PreOrderDFS(tree2)) == Any[tree2,Any[1,2],1,2,Any[3,4],3,4]
+
+    @test childcount(tree2) == 2
+    @test !isleaf(tree2)
+    @test treesize(tree2) == 7
+    @test treebreadth(tree2) == 4
+    @test treeheight(tree2) == 2
+
+
+    tree3 = []
+    for itr in [Leaves, PreOrderDFS, PostOrderDFS]
+        @test collect(itr(tree3)) == [tree3]
+    end
+
+    @test childcount(tree3) == 0
+    @test isleaf(tree3)
+    @test treesize(tree3) == 1
+    @test treebreadth(tree3) == 1
+    @test treeheight(tree3) == 0
 end
 
 

--- a/test/builtins.jl
+++ b/test/builtins.jl
@@ -14,8 +14,6 @@ using Test
     @test collect(PostOrderDFS(tree)) == Any[1,2,3,Any[2,3],Any[1,Any[2,3]]]
     @test collect(StatelessBFS(tree)) == Any[Any[1,Any[2,3]],1,Any[2,3],2,3]
 
-    @test childcount(tree) == 2
-    @test !isleaf(tree)
     @test treesize(tree) == 5
     @test treebreadth(tree) == 3
     @test treeheight(tree) == 2
@@ -43,8 +41,6 @@ using Test
     tree2 = Any[Any[1,2],Any[3,4]]
     @test collect(PreOrderDFS(tree2)) == Any[tree2,Any[1,2],1,2,Any[3,4],3,4]
 
-    @test childcount(tree2) == 2
-    @test !isleaf(tree2)
     @test treesize(tree2) == 7
     @test treebreadth(tree2) == 4
     @test treeheight(tree2) == 2
@@ -55,8 +51,6 @@ using Test
         @test collect(itr(tree3)) == [tree3]
     end
 
-    @test childcount(tree3) == 0
-    @test isleaf(tree3)
     @test treesize(tree3) == 1
     @test treebreadth(tree3) == 1
     @test treeheight(tree3) == 0

--- a/test/trees.jl
+++ b/test/trees.jl
@@ -60,8 +60,6 @@ end
 
     # Node/subtree properties
     #                              1   2  3  4  5  6  7  8  9 10 11 12 13 14 15 16
-    @test childcount.(nodes)  == [ 4, 2, 0, 1, 0, 0, 1, 4, 0, 0, 3, 0, 0, 0, 0, 0]
-    @test isleaf.(nodes)      == [ 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1]
     @test treesize.(nodes)    == [16, 4, 1, 2, 1, 1, 9, 8, 1, 1, 4, 1, 1, 1, 1, 1]
     @test treebreadth.(nodes) == [10, 2, 1, 1, 1, 1, 6, 6, 1, 1, 3, 1, 1, 1, 1, 1]
     @test treeheight.(nodes)  == [ 4, 2, 0, 1, 0, 0, 3, 2, 0, 0, 1, 0, 0, 0, 0, 0]


### PR DESCRIPTION
Added some additional API functions to get various properties of a node's direct children and subtree structure. All have default implementations that only require an implementation of `children` but of course can be overridden for performance.

Also added a new docs page on how to implement the API for new types.

*  `childcount(node)` - possibly should be called `degree`?
* `isleaf(node)` - replaces `has_children` (was undocumented and also implemented incorrectly)
* `ischild(node1, node2)`, `isdescendant(node1, node2)`, `intree(node, tree)` for querying parent/child / ancestor/descendant relationships
* `treesize`, `treeheight`, `treebreadth` for tree size and shape