### PR TITLE
Fix tree printing with non-iterable children

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -154,10 +154,20 @@ function _print_tree(printnode::Function, io::IO, tree; maxdepth = 5, indicate_t
         childindices(roottree, tree) : children(roottree, tree)
     if c !== ()
         if depth < maxdepth
-            s = Iterators.Stateful(from === nothing ? pairs(c) : Iterators.Rest(pairs(c), from))
+            it = c
+            if withinds
+                it = from === nothing ? pairs(c) : Iterators.Rest(pairs(c), from)
+            else
+                @assert from === nothing
+            end
+            s = Iterators.Stateful(it)
             while !isempty(s)
-                ind, child = popfirst!(s)
-                ind === to && break
+                if withinds
+                    ind, child = popfirst!(s)
+                    ind === to && break
+                else
+                    child = popfirst!(s)
+                end
                 active = false
                 child_active_levels = active_levels
                 print_prefix(io, depth, charset, active_levels)


### PR DESCRIPTION
The original design for this code was to not require any indexing
of the object returned by `children` at all, unless the tree was
defined to be indexable. This seems to have gotten lost over time
(or maybe it never worked, since it wasn't tested). Nevertheless
the fix is easy and let's add a test this time :).