### PR TITLE
Major refactor to print_tree()

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -32,6 +32,8 @@ AbstractTrees.DEFAULT_CHARSET
 AbstractTrees.ASCII_CHARSET
 AbstractTrees.TreeCharSet
 print_tree
+AbstractTrees.print_child_key
+AbstractTrees.printkeys_default
 AbstractTrees.printnode
 AbstractTrees.repr_node
 AbstractTrees.repr_tree

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -123,6 +123,21 @@ struct TreeCharSet
     end
 end
 
+"""
+    TreeCharSet(base::TreeCharSet; fields...)
+
+Create a new `TreeCharSet` by modifying select fields of an existing instance.
+"""
+function TreeCharSet(base::TreeCharSet;
+                     mid = base.mid,
+                     terminator = base.terminator,
+                     skip = base.skip,
+                     dash = base.dash,
+                     trunc = base.trunc,
+                     )
+    return TreeCharSet(mid, terminator, skip, dash, trunc)
+end
+
 """Default `charset` argument used by [`print_tree`](@ref)."""
 const DEFAULT_CHARSET = TreeCharSet("├", "└", "│", "─", "⋮")
 """Charset using only ASCII characters."""

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -99,9 +99,17 @@ end
 const _CharArg = Union{AbstractString, Char}
 
 """
-    TreeCharSet
+    TreeCharSet(mid, terminator, skip, dash, trunc, pair)
 
 Set of characters (or strings) used to pretty-print tree branches in [`print_tree`](@ref).
+
+# Fields
+
+* `mid::String` - "Forked" branch segment connecting to middle children.
+* `terminator::String` - Final branch segment connecting to last child.
+* `skip::String` - Vertical branch segment.
+* `dash::String` - Horizontal branch segmentt printed to the right of `mid` and `terminator`.
+* `trunc::String` - Used to indicate the subtree has been truncated at the maximum depth.
 """
 struct TreeCharSet
     mid::String

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -135,7 +135,7 @@ end
 
 function _print_tree(printnode::Function, io::IO, tree; maxdepth = 5, indicate_truncation = true,
                      depth = 0, active_levels = Int[], charset = DEFAULT_CHARSET, withinds = false,
-                     inds = [], from = nothing, to = nothing, roottree = tree)
+                     inds = [], roottree = tree)
 
     # Print node representation
 
@@ -179,24 +179,16 @@ function _print_tree(printnode::Function, io::IO, tree; maxdepth = 5, indicate_t
     end
 
     # Children or key => child pairs to print
-    it = c
-    if withinds
-        it = from === nothing ? pairs(c) : Iterators.Rest(pairs(c), from)
-    else
-        @assert from === nothing
-    end
+    it = withinds ? pairs(c) : c
     s = Iterators.Stateful(it)
 
     # Print children
     while !isempty(s)
         if withinds
             ind, child = popfirst!(s)
-            ind === to && break
         else
             child = popfirst!(s)
         end
-
-        active = false
 
         print_prefix(io, depth, charset, active_levels)
 

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -217,9 +217,9 @@ Get the string result of calling [`print_tree`](@ref) with the supplied argument
 
 The `context` argument works as it does in `Base.repr`.
 """
-function repr_tree(tree, args...; context=nothing, kw...)
+function repr_tree(tree; context=nothing, kw...)
     buf = IOBuffer()
     io = context === nothing ? buf : IOContext(buf, context)
-    print_tree(io, tree, args...; kw...)
+    print_tree(io, tree; kw...)
     return String(take!(buf))
 end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -94,22 +94,27 @@ function repr_node(node; context=nothing)
 end
 
 
+const _CharArg = Union{AbstractString, Char}
+
 """
     TreeCharSet
 
-Set of characters (or strings) used to pretty-print tree branches in
-[`print_tree`](@ref).
+Set of characters (or strings) used to pretty-print tree branches in [`print_tree`](@ref).
 """
 struct TreeCharSet
-    mid
-    terminator
-    skip
-    dash
-    trunc
+    mid::String
+    terminator::String
+    skip::String
+    dash::String
+    trunc::String
+
+    function TreeCharSet(mid::_CharArg, terminator::_CharArg, skip::_CharArg, dash::_CharArg, trunc::_CharArg)
+        return new(String(mid), String(terminator), String(skip), String(dash), String(trunc))
+    end
 end
 
 """Default `charset` argument used by [`print_tree`](@ref)."""
-const DEFAULT_CHARSET = TreeCharSet('├', '└', '│', '─', '⋮')
+const DEFAULT_CHARSET = TreeCharSet("├", "└", "│", "─", "⋮")
 """Charset using only ASCII characters."""
 const ASCII_CHARSET = TreeCharSet("+", "\\", "|", "--", "...")
 

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -165,8 +165,8 @@ function _print_tree(printnode::Function,
 
     c = isa(treekind(roottree), IndexedTree) ? childindices(roottree, tree) : children(roottree, tree)
 
-    # No children
-    c === () && return
+    # No children?
+    isempty(c) && return
 
     # Reached max depth
     if depth >= maxdepth

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -9,6 +9,8 @@ Print a text representation of `tree` to the given `io` object.
 
 * `f::Function` - custom implementation of [`printnode`](@ref) to use. Should have the
   signature `f(io::IO, node)`.
+* `io::IO` - IO stream to write to.
+* `tree` - tree to print.
 * `maxdepth::Integer = 5` - truncate printing of subtrees at this depth.
 * `indicate_truncation::Bool = true` - print a vertical ellipsis character beneath
   truncated nodes.
@@ -138,9 +140,18 @@ function print_prefix(io::IO, depth::Int, charset::TreeCharSet, active_levels)
     end
 end
 
-function _print_tree(printnode::Function, io::IO, tree; maxdepth = 5, indicate_truncation = true,
-                     depth = 0, active_levels = Int[], charset = DEFAULT_CHARSET, withinds = false,
-                     inds = [], roottree = tree)
+function _print_tree(printnode::Function,
+                     io::IO,
+                     tree;
+                     maxdepth::Int,
+                     indicate_truncation::Bool,
+                     charset::TreeCharSet,
+                     withinds::Bool,
+                     depth::Int = 0,
+                     active_levels::Vector{Int} = Int[],
+                     inds = [],
+                     roottree = tree,
+                     )
 
     # Print node representation
 
@@ -215,7 +226,17 @@ function _print_tree(printnode::Function, io::IO, tree; maxdepth = 5, indicate_t
     end
 end
 
-print_tree(f::Function, io::IO, tree; kwargs...) = _print_tree(f, io, tree; kwargs...)
+function print_tree(f::Function,
+                    io::IO,
+                    tree;
+                    maxdepth::Int = 5,
+                    indicate_truncation::Bool = true,
+                    charset::TreeCharSet = DEFAULT_CHARSET,
+                    withinds::Bool = false,
+                    )
+    _print_tree(f, io, tree; maxdepth=maxdepth, indicate_truncation=indicate_truncation,
+                charset=charset, withinds=withinds)
+end
 
 function print_tree(f::Function, io::IO, tree, maxdepth; kwargs...)
     Base.depwarn("Passing maxdepth as a positional argument is deprecated, use as a keyword argument instead.", :print_tree)

--- a/test/builtins.jl
+++ b/test/builtins.jl
@@ -7,7 +7,13 @@ using Test
     tree = Any[1,Any[2,3]]
 
     T = Vector{Any}  # This is printed as "Array{Any,1}" in older versions of Julia
-    @test repr_tree(tree) == "$T\n├─ 1\n└─ $T\n   ├─ 2\n   └─ 3\n"
+    @test repr_tree(tree) == """
+        $T
+        ├─ 1
+        └─ $T
+           ├─ 2
+           └─ 3
+        """
 
     @test collect(Leaves(tree)) == [1,2,3]
     @test collect(Leaves(tree)) isa Vector{Int}
@@ -62,7 +68,17 @@ end
 
     @test children(expr) == expr.args
 
-    @test repr_tree(expr) == "Expr(:call)\n├─ :foo\n└─ Expr(:call)\n   ├─ :+\n   ├─ Expr(:call)\n   │  ├─ :^\n   │  ├─ :x\n   │  └─ 2\n   └─ 3\n"
+    @test repr_tree(expr) == """
+        Expr(:call)
+        ├─ :foo
+        └─ Expr(:call)
+           ├─ :+
+           ├─ Expr(:call)
+           │  ├─ :^
+           │  ├─ :x
+           │  └─ 2
+           └─ 3
+        """
 
     @test collect(Leaves(expr)) == [:foo, :+, :^, :x, 2, 3]
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -112,6 +112,69 @@ AbstractTrees.printnode(io::IO, u::UnindexableChildren) = AbstractTrees.printnod
 end
 
 
+@testset "Child keys" begin
+    @testset "AbstractVector" begin
+        tree = 1:2
+
+        @test repr_tree(tree) == """
+            UnitRange{Int64}
+            ├─ 1
+            └─ 2
+            """
+
+        @test repr_tree(tree, printkeys=true) == """
+            UnitRange{Int64}
+            ├─ 1 => 1
+            └─ 2 => 2
+            """
+    end
+
+    @testset "Tuple" begin
+        tree = (1, 2)
+
+        @test repr_tree(tree) == """
+            (1, 2)
+            ├─ 1
+            └─ 2
+            """
+
+        @test repr_tree(tree, printkeys=true) == """
+            (1, 2)
+            ├─ 1 => 1
+            └─ 2 => 2
+            """
+    end
+
+    @testset "Matrix" begin
+        tree = [1 2; 3 4]
+        T = typeof(tree)  # Prints as Array{Int64, 2} on older versions of Julia
+
+        @test repr_tree(tree) == """
+            $T
+            ├─ (1, 1) => 1
+            ├─ (2, 1) => 3
+            ├─ (1, 2) => 2
+            └─ (2, 2) => 4
+            """
+
+        @test repr_tree(tree, printkeys=false) == """
+            $T
+            ├─ 1
+            ├─ 3
+            ├─ 2
+            └─ 4
+            """
+    end
+
+    @testset "No keys" begin
+        tree = UnindexableChildren(1:2)  # Has no method for Base.keys()
+
+        @test repr_tree(tree) == repr_tree(tree.node)
+        @test repr_tree(tree, printkeys=true) == repr_tree(tree.node)
+    end
+end
+
+
 @testset "print_tree maxdepth as positional argument" begin
     tree = Num(0)
 
@@ -173,5 +236,5 @@ end
     base = AbstractTrees.DEFAULT_CHARSET
 
     @test TreeCharSet(base) == base
-    @test TreeCharSet(base, terminator="...") == TreeCharSet(base.mid, "...", base.skip, base.dash, base.trunc)
+    @test TreeCharSet(base, terminator="...") == TreeCharSet(base.mid, "...", base.skip, base.dash, base.trunc, base.pair)
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -134,3 +134,36 @@ end
     tree = Num(0)
     @test repr_tree(UnindexableChildren(tree), maxdepth=4) == repr_tree(tree, maxdepth=4)
 end
+
+
+# Prints node as cool message box
+struct BoxNode
+    s::String
+    children::Vector
+end
+
+AbstractTrees.children(n::BoxNode) = n.children
+function AbstractTrees.printnode(io::IO, n::BoxNode)
+    println(io, "┌", "─" ^ textwidth(n.s), "┐")
+    println(io, "│", n.s, "│")
+    print(io, "└", "─" ^ textwidth(n.s), "┘")
+end
+
+@testset "printnode multiline" begin
+    tree = ["foo", BoxNode("bar", [1, 2:4, 5]), "baz"]
+
+    @test repr_tree(tree) == """
+        $(typeof(tree))
+        ├─ "foo"
+        ├─ ┌───┐
+        │  │bar│
+        │  └───┘
+        │  ├─ 1
+        │  ├─ UnitRange{Int64}
+        │  │  ├─ 2
+        │  │  ├─ 3
+        │  │  └─ 4
+        │  └─ 5
+        └─ "baz"
+        """
+end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -167,3 +167,11 @@ end
         └─ "baz"
         """
 end
+
+
+@testset "TreeCharSet constructor" begin
+    base = AbstractTrees.DEFAULT_CHARSET
+
+    @test TreeCharSet(base) == base
+    @test TreeCharSet(base, terminator="...") == TreeCharSet(base.mid, "...", base.skip, base.dash, base.trunc)
+end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -53,7 +53,7 @@ AbstractTrees.children(::SingleChildInfiniteDepth) = (SingleChildInfiniteDepth()
     #       └─ 3
     #
 
-    truncation_char = AbstractTrees.DEFAULT_CHARSET.trunc
+    truncation_str = AbstractTrees.DEFAULT_CHARSET.trunc
 
     for maxdepth in [3,5,8]
         ptxt = repr_tree(Num(0), maxdepth=maxdepth)
@@ -68,7 +68,7 @@ AbstractTrees.children(::SingleChildInfiniteDepth) = (SingleChildInfiniteDepth()
         lines = split(ptxt, '\n')
         for i in 1:length(lines)
             if occursin(string(maxdepth), lines[i])
-                @test lines[i+1][end] == truncation_char
+                @test endswith(lines[i+1], truncation_str)
             end
         end
     end

--- a/test/trees.jl
+++ b/test/trees.jl
@@ -138,7 +138,12 @@ Base.IteratorEltype(::Type{<:TreeIterator{OneTree}}) = Base.HasEltype()
 
 @testset "OneTree" begin
     ot = OneTree([2,3,4,0])
-    @test repr_tree(ot) == "2\n└─ 3\n   └─ 4\n      └─ 0\n"
+    @test repr_tree(ot) == """
+        2
+        └─ 3
+           └─ 4
+              └─ 0
+        """
     @test @inferred(collect(Leaves(ot))) == [0]
     @test eltype(collect(Leaves(ot))) === Int
     @test collect(PreOrderDFS(ot)) == [2,3,4,0]
@@ -170,7 +175,12 @@ AbstractTrees.printnode(io::IO, t::ParentTree) =
     ot = OneTree([2,3,4,0])
     pt = ParentTree(ot,[0,1,2,3])
 
-    @test repr_tree(pt) == "2\n└─ 3\n   └─ 4\n      └─ 0\n"
+    @test repr_tree(pt) == """
+        2
+        └─ 3
+           └─ 4
+              └─ 0
+        """
     @test collect(Leaves(pt)) == [0]
     @test collect(PreOrderDFS(pt)) == [2,3,4,0]
     @test collect(PostOrderDFS(pt)) == [0,4,3,2]


### PR DESCRIPTION
* Made formatting and structural changes to `_print_tree()` to simplify code and improve readability
* Added types to most arguments, explicit keyword arguments in public `print_tree()` function
* Removed unused `to` and `from` arguments to `_print_tree()`
* Typed `TreeCharSet` attributes as strings, constructor still accepts `Char`s. Added constructor which modifies select fields of an existing instance.
* Fix/implement index/key printing, rename `withinds` keyword argument to `printkeys`. Keys printed by default for return types of `children()` other than `AbstractVector` and `Tuple`.
* Fix bug where truncation character was printed under leaf nodes at max depth
* Test for multi-line node representations