### PR TITLE
Implement children(::AbstractDict) correctly

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -55,6 +55,7 @@ TreeIterator
 
 ```@docs
 AnnotationNode
+AbstractTrees.DictChildren
 ShadowTree
 Tree
 ```

--- a/docs/src/implementing.md
+++ b/docs/src/implementing.md
@@ -1,6 +1,9 @@
 # Implementing the AbstractTrees API
 
 
+
+## Children
+
 Consider the following custom node type, which stores a single data value along with an explicit
 list of child nodes:
 
@@ -19,7 +22,7 @@ MyNode
 ```
 
 
-All that is needed to implement the `AbstractTrees` interface for `MyNode` is to define the
+All that is needed to implement the basic `AbstractTrees` interface for `MyNode` is to define the
 appropriate method of [`children`](@ref):
 
 
@@ -61,6 +64,31 @@ tree = MyNode(1, [
  6
  1
 ```
+
+
+### Child collections
+
+The return value of `children()` does not have to be an array, it can be any collection type.
+Collection types which support indexing enable additional features of this package (TODO: which?).
+In this case the type should also have an appropriate implementation of `keys()` (and thus
+`pairs()`).
+
+Be aware that `AbstractDict` instances cannot be used directly as they behave as a collection
+of `Pair`s, which is probably not what you want. Instead wrap the dict in
+[`AbstractTrees.DictChildren`](@ref), it will behave as a collection of the dict's values only but
+still give the same result with regards to indexing and `keys()`.
+
+
+### Leaf nodes
+
+If your type should always be considered a leaf node (cannot have any children), defining
+
+```julia
+AbstractTrees.children(::MyNode) = ()
+```
+
+serves to make this property easily inferrable by the compiler, as an instance of `Tuple{}` is
+known to be empty by its type alone.
 
 
 ## Optional functions

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -19,8 +19,34 @@ end
 
 
 # AbstractDict
-printnode(io::IO, kv::Pair{K,V}) where {K,V} = printnode(io,kv[1])
-children(kv::Pair{K,V}) where {K,V} = (kv[2],)
+children(d::AbstractDict) = DictChildren(d)
+
+"""
+    DictChildren(dict)
+
+A `Dict`-like indexable collection of child nodes. `dict` is an `AbstractDict` or any other
+collection type which supports `pairs()`.
+
+Behaves as a collection of the dictionary's *values* as opposed to a collection of pairs as the
+dictionary itself does, but still supports indexing with keys. The `pairs()` function gives the same
+result as the original dict.
+"""
+struct DictChildren{K, V, D}
+    dict::D
+
+    DictChildren(dict) = new{keytype(dict), valtype(dict), typeof(dict)}(dict)
+end
+
+Base.eltype(::Type{DictChildren{K, V, D}}) where {K, V, D} = V
+Base.keytype(::Type{DictChildren{K, V, D}}) where {K, V, D} = K
+Base.valtype(::Type{DictChildren{K, V, D}}) where {K, V, D} = V
+
+Base.length(c::DictChildren) = length(c.dict)
+Base.keys(c::DictChildren) = keys(c.dict)
+Base.values(c::DictChildren) = values(c.dict)
+Base.pairs(c::DictChildren) = pairs(c.dict)
+Base.iterate(c::DictChildren, args...) = iterate(values(c.dict), args...)
+Base.getindex(c::DictChildren, key) = c.dict[key]
 
 
 # For potentially-large containers, just show the type

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -22,7 +22,7 @@ Print a text representation of `tree` to the given `io` object.
 # Examples
 
 ```jldoctest; setup = :(using AbstractTrees)
-julia> tree = [1:3, "foo", [[[4, 5], 6, 7], 8]];
+julia> tree = [1:3, "foo", Dict(:a => [4, 5], :b => 6, :c => 7)];
 
 julia> print_tree(tree)
 Vector{Any}
@@ -31,14 +31,12 @@ Vector{Any}
 │  ├─ 2
 │  └─ 3
 ├─ "foo"
-└─ Vector{Any}
-   ├─ Vector{Any}
-   │  ├─ Vector{Int64}
-   │  │  ├─ 4
-   │  │  └─ 5
-   │  ├─ 6
-   │  └─ 7
-   └─ 8
+└─ Dict{Symbol, Any}
+   ├─ :a => Vector{Int64}
+   │        ├─ 4
+   │        └─ 5
+   ├─ :b => 6
+   └─ :c => 7
 
 julia> print_tree(tree, maxdepth=2)
 Vector{Any}
@@ -47,11 +45,12 @@ Vector{Any}
 │  ├─ 2
 │  └─ 3
 ├─ "foo"
-└─ Vector{Any}
-   ├─ Vector{Any}
-   │  ⋮
+└─ Dict{Symbol, Any}
+   ├─ :a => Vector{Int64}
+   │        ⋮
    │
-   └─ 8
+   ├─ :b => 6
+   └─ :c => 7
 
 julia> print_tree(tree, charset=AbstractTrees.ASCII_CHARSET)
 Vector{Any}
@@ -60,14 +59,12 @@ Vector{Any}
 |   +-- 2
 |   \\-- 3
 +-- "foo"
-\\-- Vector{Any}
-    +-- Vector{Any}
-    |   +-- Vector{Int64}
-    |   |   +-- 4
-    |   |   \\-- 5
-    |   +-- 6
-    |   \\-- 7
-    \\-- 8
+\\-- Dict{Symbol, Any}
+    +-- :a => Vector{Int64}
+    |         +-- 4
+    |         \\-- 5
+    +-- :b => 6
+    \\-- :c => 7
 ```
 
 """


### PR DESCRIPTION
Previously the children of an `AbstractDict` were pair objects, which made printing work but otherwise didn't make a lot of sense. Now that we have functional printing of child keys in `print_tree` this can be fixed.

`children(dict::AbstractDict)` now returns `DictChildren(dict)`, which gives identical results for `keys()`, `pairs()`, and `getindex()` but behaves as a collection identical to `values(dict)`. This can also be used for user types.

Currently some tests are not passing because it looks like the current tree traversal implementations expect `children` to return something with `AbstractVector`-type indices.