### PR TITLE
Update julia compat entry

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '0.7'
           - '1.0'
           - '1'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ authors = ["Keno Fischer <keno@alumni.harvard.edu>"]
 [deps]
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
At this moment, there are only a handful developers who know how to write valid Julia 0.7 code, so let's bump the compat entry to make contributing easier?