### PR TITLE
Add LTS to CI versions.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:


### PR DESCRIPTION
Since 1.6 is the LTS, we should probably test it.