### PR TITLE
Fix tests

### DIFF
--- a/test/builtins.jl
+++ b/test/builtins.jl
@@ -44,8 +44,8 @@ using Test
     @test intree(tree, tree)
 
 
-    tree2 = Any[Any[1,2],Any[3,4]]
-    @test collect(PreOrderDFS(tree2)) == Any[tree2,Any[1,2],1,2,Any[3,4],3,4]
+    tree2 = Any[Any[1,2],Any[3,'4']]
+    @test collect(PreOrderDFS(tree2)) == Any[tree2,Any[1,2],1,2,Any[3,'4'],3,'4']
 
     @test treesize(tree2) == 7
     @test treebreadth(tree2) == 4
@@ -62,6 +62,11 @@ using Test
     @test treeheight(tree3) == 0
 end
 
+
+@testset "Pair" begin
+    tree = 1=>(3=>4)
+    @test collect(PreOrderDFS(tree)) == Any[tree, tree.second, 4]
+end
 
 @testset "Expr" begin
     expr = :(foo(x^2 + 3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,13 @@ using Test
 import Base: ==
 
 
-if v"1.1.0" < VERSION < v"1.8-" # requires https://github.com/JuliaLang/julia/pull/30291
+if v"1.1.0" < VERSION # requires https://github.com/JuliaLang/julia/pull/30291
     @testset "Ambiguities" begin
-        @test isempty(detect_ambiguities(AbstractTrees, Base, Core))
+        if  VERSION < v"1.8-"
+            @test isempty(detect_ambiguities(AbstractTrees, Base, Core))
+        else
+            @test_broken isempty(detect_ambiguities(AbstractTrees, Base, Core))
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test
 import Base: ==
 
 
-if VERSION >= v"1.1.0-DEV.838" # requires https://github.com/JuliaLang/julia/pull/30291
+if v"1.1.0" < VERSION < v"1.8-" # requires https://github.com/JuliaLang/julia/pull/30291
     @testset "Ambiguities" begin
         @test isempty(detect_ambiguities(AbstractTrees, Base, Core))
     end


### PR DESCRIPTION
1.8 adds a method for ` getindex(Q::LinearAlgebra.AbstractQ, inds...)` which is ambiguous with  `getindex(x::AbstractArray, ::AbstractTrees.ImplicitRootState)`. As such, the unit tests are failing on master. This doesn't fix the problem, but will make the unit tests useful again.