### PR TITLE
fix root check comparison

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -192,7 +192,7 @@ function _print_tree(printnode::Function,
     # Print node representation
 
     # Get node representation as string
-    toprint = tree != roottree && isa(treekind(roottree), IndexedTree) ? roottree[tree] : tree
+    toprint = tree !== roottree && isa(treekind(roottree), IndexedTree) ? roottree[tree] : tree
     str = repr_node(toprint, context=io)
 
     # Copy buffer to output, prepending prefix to each line


### PR DESCRIPTION
I wrote a tree, and this tree has a sophisticated method to compare the equivalence (to be concrete, it is a sum-product tree, I need to expand the expression).
When I print such a tree with millions of nodes, it freezes because of invoking the comparison.

This minor fix will make the root check more reliable and it solves my problem perfectly.