### PR TITLE
Restore old printnode behavior for potentially large collections

### DIFF
--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -10,3 +10,7 @@ children(p::Pair) = (p[2],)
 ChildIndexing(::Pair) = IndexedChildren()
 
 children(dict::AbstractDict) = pairs(dict)
+
+
+# For potentially-large containers, just show the type
+printnode(io::IO, ::T) where T <: Union{AbstractArray, AbstractDict} = print(io, T)


### PR DESCRIPTION
Restoring the old `printnode` method for potentially large collections (`fAbstractArray` and `AbstractDict`), which just prints the type.