### PR TITLE
Remove superfluous formal argument in method

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -266,7 +266,7 @@ function print_tree(printnode::Function, io::IO, node;
 end
 
 print_tree(io::IO, node; kw...) = print_tree(printnode, io, node; kw...)
-print_tree(tree, node; kw...) = print_tree(stdout, node; kw...)
+print_tree(node; kw...) = print_tree(stdout, node; kw...)
 
 
 """


### PR DESCRIPTION
I believe the `tree` argument here was a typo.