### PR TITLE
Unbreak Julia 1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.0'    # 1.0 is only partially tested; in the next breaking release, add [compat] 'julia = "1.6"' and drop this
           - '1.6'
           - '1'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,7 @@
 name = "AbstractTrees"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-version = "0.4.1"
 authors = ["Keno Fischer <keno@alumni.harvard.edu>"]
-
-[deps]
+version = "0.4.2"
 
 [compat]
 julia = "1"

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -19,6 +19,11 @@ include("iteration.jl")
 include("builtins.jl")
 include("printing.jl")
 
+# Julia 1.0 support (delete when we no longer support it)
+if !isdefined(Base, :isnothing)
+    isnothing(x) = x === nothing
+end
+
 
 #interface
 export ParentLinks, StoredParents, ImplicitParents

--- a/src/base.jl
+++ b/src/base.jl
@@ -130,7 +130,7 @@ function is not available.
 Equivalence is established with the `equiv` function.  Note that new methods should also define `equiv` or calls
 may fall back to the default method.
 """
-isdescendant(node1, node2; equiv=(≡)) = !equiv(node1, node2) && intree(node1, node2; equiv)
+isdescendant(node1, node2; equiv=(≡)) = !equiv(node1, node2) && intree(node1, node2; equiv=equiv)
 
 
 """

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -259,8 +259,8 @@ function print_tree(printnode::Function, io::IO, node;
         end
 
         print_tree(printnode, io, child;
-                   maxdepth, indicate_truncation, charset, printkeys,
-                   depth=depth+1, prefix=child_prefix
+                   maxdepth=maxdepth, indicate_truncation=indicate_truncation, charset=charset,
+                   printkeys=printkeys, depth=depth+1, prefix=child_prefix
                   )
     end
 end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,4 +1,5 @@
 # Ensure that we can run all files in the examples directory with no errors.
+# Note: fstree doesn't work on Julia 1.0
 
 exampledir = joinpath(dirname(@__DIR__), "examples")
 examples = readdir(exampledir)

--- a/test/examples/binarytree.jl
+++ b/test/examples/binarytree.jl
@@ -1,5 +1,8 @@
 using AbstractTrees
 
+if !isdefined(Base, :isnothing)        # Julia 1.0 support
+    using AbstractTrees: isnothing
+end
 
 mutable struct BinaryNode{T}
     data::T

--- a/test/examples/fstree.jl
+++ b/test/examples/fstree.jl
@@ -29,7 +29,8 @@ AbstractTrees.printnode(io::IO, d::Directory) = print(io, basename(d.path))
 AbstractTrees.printnode(io::IO, f::File) = print(io, basename(f.path))
 
 function mk_tree_test_dir(f, parentdir=tempdir(); prefix="jl_")
-    mktempdir(parentdir; prefix) do path
+    # While Julia 1.0 can parse this, `mktempdir` does not support the `prefix` kw
+    mktempdir(parentdir; prefix=prefix) do path
         cd(path) do
             open(io -> write(io, "test1"), "f1"; write=true)
             mkdir("A")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,7 @@ using AbstractTrees, Test
 
 @testset "Builtins" begin include("builtins.jl") end
 @testset "Custom tree types" begin include("trees.jl") end
-@testset "Printing" begin include("printing.jl") end
-
+if Base.VERSION >= v"1.6"
+    # Printing tests use `findall` variants that are not supported on Julia 1.0
+    @testset "Printing" begin include("printing.jl") end
+end

--- a/test/trees.jl
+++ b/test/trees.jl
@@ -88,7 +88,7 @@ end
 include(joinpath(@__DIR__,"examples","fstree.jl"))
 
 @testset "FSNode" begin
-    mk_tree_test_dir() do path
+    Base.VERSION >= v"1.6" && mk_tree_test_dir() do path
         tree = Directory(".")
 
         ls = nodevalue.((collect ∘ Leaves)(tree))


### PR DESCRIPTION
Version 0.4 got released claiming to support Julia 1.0
(the [compat] is `julia = "1"`) but 1.0 was dropped from CI.
Unfortunately, not only doesn't the package run on
1.0, it doesn't even parse. This means that every package
that wants to update their AbstractTrees dependency might try this

    [compat]
    AbstractTrees = "0.3, 0.4"

and while this works fine on Julia 1.6, it breaks on Julia 1.0.
Had AbstractTrees 0.4 merely declared incompatibility
with Julia 1.0, the package manager would have
handled everything for us---it would install AbstractTrees 0.3.x
on Julia 1.0, and 0.4.x on 1.6 and higher.

Now we are a bit stuck. One option is to see if General
would accept a PR retrospectively making AbstractTrees
0.4 uninstallable on 1.0. The alternative is to provide
at least minimal support for 1.0. I've taken that route here,
but I'd be equally fine with the idea of making a PR to
General.

CC @ExpandingMan