### PR TITLE
atonement for compiler abuse (type stable cursors!)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AbstractTrees"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 authors = ["Keno Fischer <keno@alumni.harvard.edu>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [compat]
 julia = "1"

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -66,29 +66,3 @@ map leaves.
 
 Introducing a new type becomes necessary to ensure that it can accommodate arbitrary output types.
 
-# Why is my code type unstable?
-Guaranteeing type stability when iterating over trees is challenging to say the least.  There are
-several major obstacles
-- The children of a tree node do not, in general, have the same type as their parent.
-- Even if it is easy to infer the type of a node's immediate children, it is usually much harder to
-    infer the types of the node's more distant descendants.
-- Navigating a tree requires inferring not just the types of the children but the types of the
-    children's *iteration states*.  To make matters worse, Julia's `Base` does not include traits
-    for describing these, and the `Base` iteration protocol makes very few assumptions about them.
-
-All of this means that you are unlikely to get type-stable code from AbstractTrees.jl without some
-effort.
-
-The simplest way around this is to define the `NodeType` trait and `nodetype` (analogous to
-`Base.IteratorEltype` and `eltype`):
-```julia
-AbstractTrees.NodeType(::Type{<:ExampleNode}) = HasNodeType()
-AbstractTrees.nodetype(::Type{<:ExampleNode}) = ExampleNode
-```
-which is equivalent to asserting that all nodes of a tree are of the same type.  Performance
-critical code must ensure that it is possible to construct such a tree, which may not be trivial.
-
-Note that even after defining `Base.eltype` it might still be difficult to achieve type-stability
-due to the aforementioned difficulties with iteration states.  The most reliable around this is to
-ensure that the object returned by `children` is indexable and that the node has the
-`IndexedChildren` state.  This guarantees that `Int` can always be used as an iteration state.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -145,6 +145,33 @@ prevsiblingindex
 rootindex
 ```
 
+## The `AbstractNode` Type
+It is not required that objects implementing the AbstractTrees.jl interface are of this type, but it
+can be used to indicate that an object *must* implement the interface.
+```@docs
+AbstractNode
+```
+
+## Type Stability and Performance
+Because of the recursive nature of trees it can be quite challenging to achieve type stability when
+traversing it in any way such as iterating over nodes.  Only trees which guarantee that all nodes
+are of the same type (with [`HasNodeType`](@ref)) can be type stable.
+
+To make it easier to convert trees with non-uniform node types this package provides the
+`StableNode` type.
+```@docs
+StableNode
+```
+
+To achieve the same performance with custom node types be sure to define at least
+```julia
+AbstractTrees.NodeType(::Type{<:ExampleNode}) = HasNodeType()
+AbstractTrees.nodetype(::Type{<:ExampleNode}) = ExampleNode
+```
+
+In some circumstances it is also more efficient for nodes to have [`ChildIndexing`](@ref) since this
+also guarantees the type of the iteration state of the iterator returned by `children`.
+
 ## Additional Functions
 ```@docs
 getdescendant

--- a/docs/src/iteration.md
+++ b/docs/src/iteration.md
@@ -34,6 +34,7 @@ PostOrderDFS
 Leaves
 Siblings
 StatelessBFS
+treemap
 ```
 
 ### Iterator States

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -19,11 +19,6 @@ include("iteration.jl")
 include("builtins.jl")
 include("printing.jl")
 
-# Julia 1.0 support (delete when we no longer support it)
-if !isdefined(Base, :isnothing)
-    isnothing(x) = x === nothing
-end
-
 
 #interface
 export ParentLinks, StoredParents, ImplicitParents
@@ -33,6 +28,8 @@ export NodeType, HasNodeType, NodeTypeUnknown
 export nodetype, nodevalue, nodevalues, children, parentlinks, siblinglinks, childindexing, childtype, childrentype
 #extended interface
 export nextsibling, prevsibling
+
+export AbstractNode, StableNode
 
 # properties
 export ischild, isroot, isroot, intree, isdescendant, treesize, treebreadth, treeheight, descendleft, getroot

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -19,6 +19,11 @@ include("iteration.jl")
 include("builtins.jl")
 include("printing.jl")
 
+# Julia 1.0 support (delete when we no longer support it)
+if !isdefined(Base, :isnothing)
+    isnothing(x) = x === nothing
+end
+
 
 #interface
 export ParentLinks, StoredParents, ImplicitParents

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -271,7 +271,10 @@ struct StableCursor{N,S} <: TreeCursor{N,N}
 
     # note that this very deliberately takes childstatetype(n) and *not* childstatetype(p)
     # this is because p may be nothing
-    StableCursor(p, n, st) = new{typeof(n),childstatetype(n)}(p, n, st)
+    StableCursor(::Nothing, n, st) = new{typeof(n),childstatetype(n)}(nothing, n, st)
+    
+    # this method is important for eliminating expensive calls to childstatetype
+    StableCursor(p::StableCursor{N,S}, n, st) where {N,S} = new{N,S}(p, n, st)
 end
 
 StableCursor(node) = StableCursor(nothing, node, nothing)

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -10,7 +10,7 @@ struct InitialState end
 
 
 """
-    TreeCursor{P,N}
+    TreeCursor{N,P}
 
 Abstract type for tree cursors which when constructed from a node can be used to
 navigate the entire tree descended from that node.
@@ -25,6 +25,12 @@ Tree nodes which define `children` and have the traits [`StoredParents`](@ref) a
 [`StoredSiblings`](@ref) satisfy the `TreeCursor` interface, but calling `TreeCursor(node)` on such
 a node wraps them in a [`TrivialCursor`](@ref) to maintain a consistent interface.
 
+Note that any `TreeCursor` created from a non-cursor node is the root of its own tree, but can be created
+from any tree node.  For example the cursor created from the tree `[1,[2,3]]` corresponding to node with
+value `[2,3]` has no parent and children `2` and `3`.  This is because a cursor created this way cannot
+infer the iteration state of its siblings.  These constructors are still allowed so that users can
+run tree algorithms over non-root nodes but they do not permit ascension from the initial node.
+
 ## Constructors
 All `TreeCursor`s possess (at least) the following constructors
 - `T(node)`
@@ -32,14 +38,14 @@ All `TreeCursor`s possess (at least) the following constructors
 
 In the former case the `TreeCursor` is constructed for the tree of which `node` is the root.
 """
-abstract type TreeCursor{P,N} end
+abstract type TreeCursor{N,P} end
 
 """
     nodevaluetype(csr::TreeCursor)
 
 Get the type of the wrapped node.  This should match the return type of [`nodevalue`](@ref).
 """
-nodevaluetype(::Type{<:TreeCursor{P,N}}) where {P,N} = N
+nodevaluetype(::Type{<:TreeCursor{N,P}}) where {N,P} = N
 nodevaluetype(csr::TreeCursor) = nodevaluetype(typeof(csr))
 
 """
@@ -48,13 +54,16 @@ nodevaluetype(csr::TreeCursor) = nodevaluetype(typeof(csr))
 The return type of `parent(csr)`.  For properly constructed `TreeCursor`s this is guaranteed to be another
 `TreeCursor`.
 """
-parenttype(::Type{<:TreeCursor{P,N}}) where {P,N} = P
+parenttype(::Type{<:TreeCursor{N,P}}) where {N,P} = P
 parenttype(csr::TreeCursor) = parenttype(typeof(csr))
 
 # this is a fallback and may not always be the case
-Base.IteratorSize(::Type{<:TreeCursor{P,N}}) where {P,N} = IteratorSize(childtype(N))
+Base.IteratorSize(::Type{<:TreeCursor{N,P}}) where {N,P} = Base.IteratorSize(childrentype(N))
 
-Base.length(tc::TreeCursor) = (length ∘ children ∘ nodevalue)(csr)
+Base.length(tc::TreeCursor) = (length ∘ children ∘ nodevalue)(tc)
+
+# this is needed in case an iterator declares IteratorSize to be HasSize
+Base.size(tc::TreeCursor) = (size ∘ children ∘ nodevalue)(tc)
 
 Base.IteratorEltype(::Type{<:TreeCursor}) = EltypeUnknown()
 
@@ -73,18 +82,21 @@ parent(tc::TreeCursor) = tc.parent
 
 
 """
-    TrivialCursor{P,N} <: TreeCursor{P,N}
+    TrivialCursor{N,P} <: TreeCursor{N,P}
 
 A [`TreeCursor`](@ref) which matches the functionality of the underlying node.  Tree nodes wrapped by this
 cursor themselves have most of the functionality required of a `TreeCursor`, this type exists entirely
 for the sake of maintaining a fully consistent interface with other `TreeCursor` objects.
 """
-struct TrivialCursor{P,N} <: TreeCursor{P,N}
-    parent::P
+struct TrivialCursor{N,P} <: TreeCursor{N,P}
+    parent::P  # unlike in most other cursors, this is not a cursor
     node::N
 end
 
-parent(csr::TrivialCursor) = parent(csr.node)
+function parent(csr::TrivialCursor)
+    isnothing(csr.parent) && return nothing
+    TrivialCursor(parent(csr.parent), csr.parent)
+end
 
 TrivialCursor(node) = TrivialCursor(parent(node), node)
 
@@ -109,34 +121,35 @@ end
 
 
 """
-    ImplicitCursor{P,N,S} <: TreeCursor{P,N}
+    ImplicitCursor{N,P,S} <: TreeCursor{N,P}
 
 A [`TreeCursor`](@ref) which wraps nodes which cannot efficiently access either their parents or siblings directly.
 This should be thought of as a "worst case scenario" tree cursor.  In particular, `ImplicitCursor`s store the
 child iteration state of type `S` and for any of `ImplicitCursor`s method to be type-stable it must be possible
 to infer the child iteration state type, see [`childstatetype`](@ref).
 """
-struct ImplicitCursor{P,N,S} <: TreeCursor{P,N}
-    parent::P
+struct ImplicitCursor{N,P,S} <: TreeCursor{N,P}
+    parent::Union{Nothing,ImplicitCursor}
     node::N
-    sibling_state::S
+    nextsibstate::S
 
-    ImplicitCursor(p::Union{Nothing,ImplicitCursor}, n, s=InitialState()) = new{typeof(p),typeof(n),typeof(s)}(p, n, s)
+    function ImplicitCursor(p::Union{Nothing,ImplicitCursor}, n, s)
+        cst = isnothing(p) ? Any : childstatetype(nodevalue(p))
+        new{typeof(n),typeof(nodevalue(p)),cst}(p, n, s)
+    end
 end
 
-ImplicitCursor(node) = ImplicitCursor(nothing, node)
+ImplicitCursor(node) = ImplicitCursor(nothing, node, nothing)
 
-Base.IteratorEltype(::Type{<:ImplicitCursor}) = HasEltype()
+Base.IteratorEltype(::Type{<:ImplicitCursor}) = EltypeUnknown()
 
-function Base.eltype(::Type{ImplicitCursor{P,N,S}}) where {P,N,S}
-    cst = (childstatetype ∘ nodevalueeltype)(P)
-    P′ = ImplicitCursor{P,N,S}
-    ImplicitCursor{P′,childtype(N),cst}
+function Base.eltype(::Type{ImplicitCursor{N,P,S}}) where {N,P,S}
+    ImplicitCursor{childtype(N),N,childstatetype(P)}
 end
 
 function Base.eltype(csr::ImplicitCursor)
     cst = (childstatetype ∘ parent ∘ nodevalue)(csr)
-    ImplicitCursor{typeof(csr),childtype(nodevalue(csr)),cst}
+    ImplicitCursor{childtype(nodevalue(csr)),nodevaluetype(csr),cst}
 end
 
 function Base.iterate(csr::ImplicitCursor, s=InitialState())
@@ -145,23 +158,23 @@ function Base.iterate(csr::ImplicitCursor, s=InitialState())
     r = s isa InitialState ? iterate(cs) : iterate(cs, s)
     isnothing(r) && return nothing
     (n′, s′) = r
-    o = ImplicitCursor(csr, n′, s′)
+    # next cursor requires 1 extra iteration to store next sibling
+    ns = iterate(cs, s′)
+    o = ImplicitCursor(csr, n′, ns)
     (o, s′)
 end
 
 function nextsibling(csr::ImplicitCursor)
-    isroot(csr) && return nothing
-    cs = (children ∘ nodevalue ∘ parent)(csr)
-    # do NOT just write an iterate(x, ::InitialState) method, it's an ambiguity nightmare
-    r = csr.sibling_state isa InitialState ? iterate(cs) : iterate(cs, csr.sibling_state)
-    isnothing(r) && return nothing
-    (n′, s′) = r
-    ImplicitCursor(parent(csr), n′, s′)
+    st = csr.nextsibstate
+    isnothing(st) && return nothing
+    (n, s) = st
+    ns = iterate(children(nodevalue(parent(csr))), s)
+    ImplicitCursor(csr.parent, n, ns)
 end
 
 
 """
-    IndexedCursor{P,N} <: TreeCursor{P,N}
+    IndexedCursor{N,P} <: TreeCursor{N,P}
 
 A [`TreeCursor`](@ref) for tree nodes with the [`IndexedChildren`](@ref) trait but for which parents and siblings
 are not directly accessible.
@@ -170,23 +183,20 @@ This type is very similar to [`ImplicitCursor`](@ref) except that it is free to 
 state is an integer starting at `1` which drastially simplifies type inference and slightly simplifies the
 iteration methods.
 """
-struct IndexedCursor{P,N} <: TreeCursor{P,N}
-    parent::P
+struct IndexedCursor{N,P} <: TreeCursor{N,P}
+    parent::Union{Nothing,IndexedCursor}
     node::N
     index::Int
 
-    IndexedCursor(p::Union{Nothing,IndexedCursor}, n, idx::Integer=1) = new{typeof(p),typeof(n)}(p, n, idx)
+    IndexedCursor(p::Union{Nothing,IndexedCursor}, n, idx::Integer=1) = new{typeof(n),typeof(nodevalue(p))}(p, n, idx)
 end
 
-IndexedCursor(node) = IndexedCursor(nothing, node)
+IndexedCursor(node)  = IndexedCursor(nothing, node)
 
 Base.IteratorSize(::Type{<:IndexedCursor}) = HasLength()
 
-function Base.eltype(::Type{IndexedCursor{P,N}}) where {P,N}
-    P′ = IndexedCursor{P,N}
-    IndexedCursor{P′,childtype(N)}
-end
-Base.eltype(csr::IndexedCursor) = IndexedCursor{typeof(csr),childtype(nodevalue(csr))}
+Base.eltype(::Type{IndexedCursor{N,P}}) where {N,P} = IndexedCursor{childtype(N),N}
+Base.eltype(csr::IndexedCursor) = IndexedCursor{childtype(nodevalue(csr)),nodevaluetype(csr)}
 Base.length(csr::IndexedCursor) = (length ∘ children ∘ nodevalue)(csr)
 
 function Base.getindex(csr::IndexedCursor, idx)
@@ -215,38 +225,30 @@ end
 
 
 """
-    SiblingCursor{P,N} <: TreeCursor{P,N}
+    SiblingCursor{N,P} <: TreeCursor{N,P}
 
 A [`TreeCursor`](@ref) for trees with the [`StoredSiblings`](@ref) trait.
 """
-struct SiblingCursor{P,N} <: TreeCursor{P,N}
-    parent::P
+struct SiblingCursor{N,P} <: TreeCursor{N,P}
+    parent::Union{Nothing,SiblingCursor}
     node::N
 
-    SiblingCursor(p::Union{Nothing,SiblingCursor}, n) = new{typeof(p),typeof(n)}(p, n)
+    SiblingCursor(p::Union{Nothing,SiblingCursor}, n) = new{typeof(n),typeof(nodevalue(p))}(p, n)
 end
 
 SiblingCursor(node) = SiblingCursor(nothing, node)
 
-Base.IteratorSize(::Type{SiblingCursor{P,N}}) where {P,N} = IteratorSize(childtype(N))
-
 Base.IteratorEltype(::Type{<:SiblingCursor}) = HasEltype()
 
-function Base.eltype(::Type{SiblingCursor{P,N}}) where {P,N}
-    cst = (childstatetype ∘ nodevaluetype)(P)
-    P′ = SiblingCursor{P,N}
-    SiblingCursor{P′,childtype(N)}
-end
+Base.eltype(::Type{SiblingCursor{N,P}}) where {N,P} = SiblingCursor{childtype(N),N}
 
-Base.eltype(csr::SiblingCursor) = SiblingCursor{typeof(csr),childtype(nodevalue(csr))}
-
-function Base.iterate(csr::SiblingCursor, (c, s)=(nothing, InitialState()))
+function Base.iterate(csr::SiblingCursor, s=InitialState())
     cs = (children ∘ nodevalue)(csr)
     r = s isa InitialState ? iterate(cs) : iterate(cs, s)
     isnothing(r) && return nothing
     (n′, s′) = r
     o = SiblingCursor(csr, n′)
-    (o, (o, s′))
+    (o, s′)
 end
 
 function nextsibling(csr::SiblingCursor)
@@ -260,11 +262,98 @@ function prevsibling(csr::SiblingCursor)
 end
 
 
-TreeCursor(::ChildIndexing, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
+struct StableCursor{N,S} <: TreeCursor{N,N}
+    parent::Union{Nothing,StableCursor{N,S}}
+    node::N
+    # includes the full return type of `iterate` for siblings and is guaranteed to be a
+    # Union{Nothing,T} type
+    nextsibstate::S
 
-TreeCursor(::ChildIndexing, ::ImplicitParents, ::StoredSiblings, node) = SiblingCursor(node)
+    # note that this very deliberately takes childstatetype(n) and *not* childstatetype(p)
+    # this is because p may be nothing
+    StableCursor(p, n, st) = new{typeof(n),childstatetype(n)}(p, n, st)
+end
 
-TreeCursor(::NonIndexedChildren, ::ParentLinks, ::ImplicitSiblings, node) = ImplicitCursor(node)
-TreeCursor(::IndexedChildren, ::ParentLinks, ::ImplicitSiblings, node) = IndexedCursor(node)
+StableCursor(node) = StableCursor(nothing, node, nothing)
 
-TreeCursor(node) = TreeCursor(ChildIndexing(node), ParentLinks(node), SiblingLinks(node), node)
+Base.IteratorEltype(::Type{<:StableCursor}) = HasEltype()
+
+Base.eltype(::Type{T}) where {T<:StableCursor} = T
+
+function Base.iterate(csr::StableCursor, s=InitialState())
+    cs = (children ∘ nodevalue)(csr)
+    r = s isa InitialState ? iterate(cs) : iterate(cs, s)
+    isnothing(r) && return nothing
+    (n′, s′) = r
+    # next cursor requires 1 extra iteration to store next sibling
+    ns = iterate(cs, s′)
+    o = StableCursor(csr, n′, ns)
+    (o, s′)
+end
+
+function nextsibling(csr::StableCursor)
+    st = csr.nextsibstate
+    isnothing(st) && return nothing
+    # if we got here it also guarantees that there are more siblings
+    (n, s) = st
+    ns = iterate(children(nodevalue(parent(csr))), s)
+    StableCursor(csr.parent, n, ns)
+end
+
+
+struct StableIndexedCursor{N} <: TreeCursor{N,N}
+    parent::Union{Nothing,StableIndexedCursor{N}}
+    node::N
+    index::Int
+
+    StableIndexedCursor(p::Union{Nothing,StableIndexedCursor}, n, idx::Integer=1) = new{typeof(n)}(p, n, idx)
+end
+
+StableIndexedCursor(node) = StableIndexedCursor(nothing, node)
+
+Base.IteratorSize(::Type{<:StableIndexedCursor}) = HasLength()
+
+Base.IteratorEltype(::Type{<:StableIndexedCursor}) = HasEltype()
+
+Base.eltype(::Type{T}) where {T<:StableIndexedCursor} = T
+
+Base.length(csr::StableIndexedCursor) = (length ∘ children ∘ nodevalue)(csr)
+
+function Base.getindex(csr::StableIndexedCursor, idx)
+    cs = (children ∘ nodevalue)(csr)
+    StableIndexedCursor(csr, cs[idx], idx)
+end
+
+function Base.iterate(csr::StableIndexedCursor, idx=1)
+    idx > length(csr) && return nothing
+    (csr[idx], idx+1)
+end
+
+function nextsibling(csr::StableIndexedCursor)
+    p = parent(csr)
+    isnothing(p) && return nothing
+    idx = csr.index + 1
+    idx > length(p) && return nothing
+    p[idx]
+end
+
+function prevsibling(csr::StableIndexedCursor)
+    idx = csr.index - 1
+    idx < 1 && return nothing
+    parent(csr)[idx]
+end
+
+
+TreeCursor(node) = TreeCursor(NodeType(node), ChildIndexing(node), ParentLinks(node), SiblingLinks(node), node)
+
+TreeCursor(::HasNodeType, ::IndexedChildren, ::ParentLinks, ::SiblingLinks, node) = StableIndexedCursor(node)
+TreeCursor(::HasNodeType, ::NonIndexedChildren, ::ParentLinks, ::SiblingLinks, node) = StableCursor(node)
+
+TreeCursor(::NodeTypeUnknown, ::IndexedChildren, ::ParentLinks, ::SiblingLinks, node) = IndexedCursor(node)
+
+TreeCursor(::NodeTypeUnknown, ::ChildIndexing, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
+
+TreeCursor(::NodeTypeUnknown, ::ChildIndexing, ::ImplicitParents, ::StoredSiblings, node) = SiblingCursor(node)
+
+TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::ParentLinks, ::ImplicitSiblings, node) = ImplicitCursor(node)
+

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -360,3 +360,6 @@ TreeCursor(::NodeTypeUnknown, ::ChildIndexing, ::ImplicitParents, ::StoredSiblin
 
 TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::ParentLinks, ::ImplicitSiblings, node) = ImplicitCursor(node)
 
+# extra methods to resolve ambiguity
+TreeCursor(::NodeTypeUnknown, ::IndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
+TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -81,6 +81,17 @@ nodevalue(tc::TreeCursor) = tc.node
 parent(tc::TreeCursor) = tc.parent
 
 
+#====================================================================================================
+Note for developers:
+
+The following code for `TreeCursor` types contains a fair amount of code duplication.
+In particular, some of the cursors can probably be combined (e.g. ImplicitCursor and StableCursor).
+
+This duplication is deliberate: cursors can get very subtle and it is rather easy to break them,
+break their type stability or cause O(tree_depth) recursive compilation costs.
+====================================================================================================#
+
+
 """
     TrivialCursor{N,P} <: TreeCursor{N,P}
 

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -430,7 +430,7 @@ Every `MapNode` is itself a tree with the [`IndexedChildren`](@ref) trait and th
 
 Use [`AbstractTrees.nodevalue`](@ref) or `mapnode.value` to obtain the wrapped value.
 """
-struct MapNode{T,C}
+struct MapNode{T,C} <: AbstractNode{T}
     value::T
     children::C
 
@@ -449,13 +449,6 @@ childrentype(::Type{MapNode{T,C}}) where {T,C} = C
 nodevalue(μ::MapNode) = μ.value
 
 ChildIndexing(::MapNode) = IndexedChildren()
-
-function Base.show(io::IO, μ::MapNode)
-    print(io, typeof(μ))
-    print(io, "(", μ.value, ")")
-end
-
-Base.show(io::IO, ::MIME"text/plain", μ::MapNode) = print_tree(io, μ)
 
 
 """
@@ -478,6 +471,8 @@ Note that in most common cases tree nodes are of a type which depends on their c
 It's very easy to write an `f` that makes `treemap` stack-overflow.  To avoid this, ensure that `f` eventually
 termiantes, i.e. that sometimes it returns empty `children`.  For example, if `f(n) = (nothing, [0; children(n)])` will
 stack-overflow because every node will have at least 1 child.
+
+To create a tree with [`HasNodeType`](@ref) which enables efficient iteration, see [`StableNode`](@ref) instead.
 
 ## Examples
 ```julia

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -143,7 +143,7 @@ If the `childrentype` can be inferred from the type of the node alone, the type 
 **OPTIONAL**: In most cases, [`childtype`](@ref) is used instead.  If `childtype` is not defined it will fall back
 to `eltype ∘ childrentype`.
 """
-childrentype(nodetype::Type) = Base._return_type(children, Tuple{nodetype})
+childrentype(::Type{T}) where {T} = Base._return_type(children, Tuple{T})
 childrentype(node) = typeof(children(node))
 
 """

--- a/test/builtins.jl
+++ b/test/builtins.jl
@@ -86,3 +86,25 @@ end
     @test nodevalue.(PostOrderDFS(b)) == [0, 1, 0, 2, 0, 3, nothing, nothing, nothing]
 end
 
+@testset "StableNode" begin
+    t = [1,[2,3,[4,5]]]
+
+    n = StableNode{Union{Int,Nothing}}(t) do m
+        m isa Integer ? convert(Int, m) : nothing
+    end
+
+    @test treeheight(n) == 3
+    @test treebreadth(n) == 5
+
+    @test typeof(TreeCursor(n)) == AbstractTrees.StableIndexedCursor{StableNode{Union{Int,Nothing}}}
+
+    ls = @inferred collect(Leaves(n))
+    ls = nodevalue.(ls)
+    @test eltype(ls) <: Union{Nothing,Int}
+    @test nodevalue.(ls) == 1:5
+
+    ns = @inferred collect(PreOrderDFS(n))
+    ns = nodevalue.(ns)
+    @test eltype(ns) == Union{Nothing,Int}
+    @test ns == [nothing, 1, nothing, 2, 3, nothing, 4, 5]
+end


### PR DESCRIPTION
This PR does the following:
- All cursors now have type parameters for parent which only give the unwrapped (non-cursor) type of the parent.  This should eliminate the compiler catastrophe of #117.
- Cursor type signatures have been re-arranged slightly to allow for easier typing of parents.  I'm not really taking advantage of this yet since it still requires one to define a bunch of confusing and annoying conversions, but in the long run it will make it easier to narrow cursor parent types somewhat.
- `StableCursor` has been added to give type-stable iteration over trees with `HasNodeType`.
- `StableIndexedCursor` has been added which allows *really, really* type-stable iteration over trees with both `HasNodeType` and `IndexedChildren`.  That is, unlike `StableCursor`, it does not rely on any crazy inference shenanigans like `Iterators.approx_iter_type`.  If you want really fast tree traversal, you should define a node type that can use this.

I have not comprehensively benchmarked this, but so far according to `@code_warntype` and `@btime` it looks like this is doing more-or-less what we want.  In particular, it definitely is type stable for `HasNodeType` (though if you repeatedly call `StableCursor` it will repeatedly call `Iterators.approx_iter_type` which is slow, so it's not perfect).

I have a bunch more things I'd like to do in this PR, but I wanted to get it in front of maintainers since this is all very tricky and confusing.  There is a fair amount of code duplication here, far more than I would permit in most circumstances.  Arguably we should find a way to combine `ImplicitCursor` and `StableCursor`.  However, I find all this so subtle, confusing and tricky that I think it will be a boon rather than a burden to the ongoing maintenance of this package to allow for a bit of code duplication.  If I were to really follow all the way through and combine everything as much as possible the result would be far too clever and would be much more difficult to maintain than what's here now (to me at least).

## TODO
- [x] Add `AbstractNode` (#115).  Fortunately we will have 2 types in the package which can inherit from this.
- [x] Add some convenience functions for making non-type-stable trees type-stable.  For example, nested arrays with leaves of a common type should be easy to turn into type-stable trees with node-values of type `Union{Nothing,T}` where `T` is the array `eltype`.  Since this is the only way to get fast tree traversal we should make it as easy as possible.  This shouldn't be hard, it will merely involve creating some simple recursive constructors for a new `StableNode` type.
- [x] Add some more unit tests for cursors.
- [x] Clean up docs and docstrings.

## Breakage?
Technically anything we do to fix #117 will be breaking because it's impossible to fix without changing the type signatures of all `TreeCursor`s.  However, I rate it *extremely* unlikely that it will actually break any packages.  In fact, it shouldn't even break unit tests.  Therefore it's worth discussing whether its' worth tagging 0.5.  Because of the ubiquity of this package in the ecosystem it might be worth running automated tests on dependencies to see if we can manage it.