### PR TITLE
Prevent isempty(children(node)) from calling iterate (20% improvement in iteration speed)

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -152,7 +152,7 @@ Get the number of leaves in the tree rooted at `node`. Leaf nodes have a breadth
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treebreadth(node) = ischildenempty(children(node)) ? 1 : mapreduce(treebreadth, +, children(node))
+treebreadth(node) = ischildrenempty(children(node)) ? 1 : mapreduce(treebreadth, +, children(node))
 
 
 """
@@ -163,7 +163,7 @@ Get the maximum depth from `node` to any of its descendants. Leaf nodes have a h
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treeheight(node) = ischildenempty(children(node)) ? 0 : 1 + mapreduce(treeheight, max, children(node))
+treeheight(node) = ischildrenempty(children(node)) ? 0 : 1 + mapreduce(treeheight, max, children(node))
 
 """
     descendleft(node)
@@ -173,7 +173,7 @@ Descend from the node `node` to the first encountered leaf node by recursively c
 """
 function descendleft(node)
     ch = children(node)
-    ischildenempty(ch) && return node
+    ischildrenempty(ch) && return node
     descendleft(first(ch))
 end
 
@@ -276,10 +276,10 @@ end
 # isempty check for children that is consistent with interface
 # without this the fallback isempty can waste a call to iterate
 # tested the test (ch===()) but it ended up being slopwer
-ischildenempty(@nospecialize ch::Tuple) = (@inline; ch == ())
+ischildrenempty(@nospecialize ch::Tuple) = (@inline; ch == ())
 
 #fallback definition
-ischildenempty(ch) =  (@inline; isempty(ch))
+ischildrenempty(ch) =  (@inline; isempty(ch))
 
 
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -275,10 +275,11 @@ end
 
 # isempty check for children that is consistent with interface
 # without this the fallback isempty can waste a call to iterate
-ischildenempty(ch::Tuple) = ch == ()
+# tested the test (ch===()) but it ended up being slopwer
+ischildenempty(@nospecialize ch::Tuple) = (@inline; ch == ())
 
 #fallback definition
-ischildenempty(ch) =  isempty(ch)
+ischildenempty(ch) =  (@inline; isempty(ch))
 
 
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -152,7 +152,7 @@ Get the number of leaves in the tree rooted at `node`. Leaf nodes have a breadth
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treebreadth(node) = isempty(children(node)) ? 1 : mapreduce(treebreadth, +, children(node))
+treebreadth(node) = isemptychild(children(node)) ? 1 : mapreduce(treebreadth, +, children(node))
 
 
 """
@@ -163,7 +163,7 @@ Get the maximum depth from `node` to any of its descendants. Leaf nodes have a h
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treeheight(node) = isempty(children(node)) ? 0 : 1 + mapreduce(treeheight, max, children(node))
+treeheight(node) = isemptychild(children(node)) ? 0 : 1 + mapreduce(treeheight, max, children(node))
 
 """
     descendleft(node)
@@ -173,7 +173,7 @@ Descend from the node `node` to the first encountered leaf node by recursively c
 """
 function descendleft(node)
     ch = children(node)
-    isempty(ch) && return node
+    isemptychild(ch) && return node
     descendleft(first(ch))
 end
 
@@ -272,4 +272,15 @@ ChildIndexing(::Type{<:StableNode}) = IndexedChildren()
 function StableNode{T}(𝒻, node) where {T}
     StableNode{T}(convert(T, 𝒻(node)), map(n -> StableNode{T}(𝒻, n), children(node)))
 end
+
+
+isemptychild(ch::Tuple) = ch == () 
+function isemptychild(ch) 
+     isempty(ch)
+end
+
+function isemptychild(x::AbstractArray)
+    length(x) == 0
+end
+
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -273,13 +273,14 @@ function StableNode{T}(𝒻, node) where {T}
     StableNode{T}(convert(T, 𝒻(node)), map(n -> StableNode{T}(𝒻, n), children(node)))
 end
 
-#isempty check that is consistent with interface
+# isempty check for children that is consistent with interface
+# without this the fallback isempty can waste a call to iterate
 ischildenempty(ch::Tuple) = ch == ()
 
 #fallback definition
 ischildenempty(ch) =  isempty(ch)
 
-ischildenempty(x::AbstractArray) =  length(x) == 0 
+
 
 
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -152,7 +152,7 @@ Get the number of leaves in the tree rooted at `node`. Leaf nodes have a breadth
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treebreadth(node) = isemptychild(children(node)) ? 1 : mapreduce(treebreadth, +, children(node))
+treebreadth(node) = ischildenempty(children(node)) ? 1 : mapreduce(treebreadth, +, children(node))
 
 
 """
@@ -163,7 +163,7 @@ Get the maximum depth from `node` to any of its descendants. Leaf nodes have a h
 By default this recurses through all nodes in the tree and so may be slow if a more specialized
 method has not been implemented for the given type.
 """
-treeheight(node) = isemptychild(children(node)) ? 0 : 1 + mapreduce(treeheight, max, children(node))
+treeheight(node) = ischildenempty(children(node)) ? 0 : 1 + mapreduce(treeheight, max, children(node))
 
 """
     descendleft(node)
@@ -173,7 +173,7 @@ Descend from the node `node` to the first encountered leaf node by recursively c
 """
 function descendleft(node)
     ch = children(node)
-    isemptychild(ch) && return node
+    ischildenempty(ch) && return node
     descendleft(first(ch))
 end
 
@@ -273,14 +273,13 @@ function StableNode{T}(𝒻, node) where {T}
     StableNode{T}(convert(T, 𝒻(node)), map(n -> StableNode{T}(𝒻, n), children(node)))
 end
 
+#isempty check that is consistent with interface
+ischildenempty(ch::Tuple) = ch == ()
 
-isemptychild(ch::Tuple) = ch == () 
-function isemptychild(ch) 
-     isempty(ch)
-end
+#fallback definition
+ischildenempty(ch) =  isempty(ch)
 
-function isemptychild(x::AbstractArray)
-    length(x) == 0
-end
+ischildenempty(x::AbstractArray) =  length(x) == 0 
+
 
 

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -9,11 +9,3 @@ children(x::Expr) = x.args
 children(p::Pair) = (p[2],)
 
 children(dict::AbstractDict) = pairs(dict)
-
-# ischildrenempty definition for built in type
-ischildenempty(x::AbstractArray) =  length(x) == 0 
-
-ischildenempty(x::AbstractDict) =  length(x) == 0 
-
-# Pairs is an AbstractDict  so this is covered under that efintion
-# ischildenempty(x::Pairs) =  length(x) == 0 

--- a/src/builtins.jl
+++ b/src/builtins.jl
@@ -9,3 +9,11 @@ children(x::Expr) = x.args
 children(p::Pair) = (p[2],)
 
 children(dict::AbstractDict) = pairs(dict)
+
+# ischildrenempty definition for built in type
+ischildenempty(x::AbstractArray) =  length(x) == 0 
+
+ischildenempty(x::AbstractDict) =  length(x) == 0 
+
+# Pairs is an AbstractDict  so this is covered under that efintion
+# ischildenempty(x::Pairs) =  length(x) == 0 

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -375,6 +375,6 @@ TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::ParentLinks, ::ImplicitSib
 TreeCursor(::NodeTypeUnknown, ::IndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
 TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
 
-function isemptychild(x::TreeCursor)
-    isemptychild(children(nodevalue(x)))
+function ischildenempty(x::TreeCursor)
+    ischildenempty(children(nodevalue(x)))
 end

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -283,7 +283,7 @@ struct StableCursor{N,S} <: TreeCursor{N,N}
     # note that this very deliberately takes childstatetype(n) and *not* childstatetype(p)
     # this is because p may be nothing
     StableCursor(::Nothing, n, st) = new{typeof(n),childstatetype(n)}(nothing, n, st)
-    
+
     # this method is important for eliminating expensive calls to childstatetype
     StableCursor(p::StableCursor{N,S}, n, st) where {N,S} = new{N,S}(p, n, st)
 end
@@ -375,6 +375,6 @@ TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::ParentLinks, ::ImplicitSib
 TreeCursor(::NodeTypeUnknown, ::IndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
 TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
 
-function ischildenempty(x::TreeCursor)
-    (ischildenempty ∘ children ∘ nodevalue)(x)
-end 
+function ischildrenempty(x::TreeCursor)
+    (ischildrenempty ∘ children ∘ nodevalue)(x)
+end

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -376,5 +376,5 @@ TreeCursor(::NodeTypeUnknown, ::IndexedChildren, ::StoredParents, ::StoredSiblin
 TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
 
 function ischildenempty(x::TreeCursor)
-    ischildenempty(children(nodevalue(x)))
-end
+    (ischildenempty ∘ children ∘ nodevalue)(x)
+end 

--- a/src/cursors.jl
+++ b/src/cursors.jl
@@ -374,3 +374,7 @@ TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::ParentLinks, ::ImplicitSib
 # extra methods to resolve ambiguity
 TreeCursor(::NodeTypeUnknown, ::IndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
 TreeCursor(::NodeTypeUnknown, ::NonIndexedChildren, ::StoredParents, ::StoredSiblings, node) = TrivialCursor(node)
+
+function isemptychild(x::TreeCursor)
+    isemptychild(children(nodevalue(x)))
+end

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -107,7 +107,7 @@ initial(::Type{PreOrderState}, node) = PreOrderState(node)
 function next(f, s::PreOrderState)
     if f(nodevalue(s.cursor))
         ch = children(s.cursor)
-        ischildenempty(ch) || return instance(PreOrderState, first(ch))
+        ischildrenempty(ch) || return instance(PreOrderState, first(ch))
     end
 
     csr = s.cursor
@@ -376,7 +376,7 @@ Base.iterate(ti::StatelessBFS) = (ti.root, [])
 function _descend_left(inds, next_node, level)
     while length(inds) ≠ level
         ch = children(next_node)
-        ischildenempty(ch) && break
+        ischildrenempty(ch) && break
         push!(inds, 1)
         next_node = first(ch)
     end

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -107,7 +107,7 @@ initial(::Type{PreOrderState}, node) = PreOrderState(node)
 function next(f, s::PreOrderState)
     if f(nodevalue(s.cursor))
         ch = children(s.cursor)
-        isemptychild(ch) || return instance(PreOrderState, first(ch))
+        ischildenempty(ch) || return instance(PreOrderState, first(ch))
     end
 
     csr = s.cursor
@@ -376,7 +376,7 @@ Base.iterate(ti::StatelessBFS) = (ti.root, [])
 function _descend_left(inds, next_node, level)
     while length(inds) ≠ level
         ch = children(next_node)
-        isemptychild(ch) && break
+        ischildenempty(ch) && break
         push!(inds, 1)
         next_node = first(ch)
     end

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -107,7 +107,7 @@ initial(::Type{PreOrderState}, node) = PreOrderState(node)
 function next(f, s::PreOrderState)
     if f(nodevalue(s.cursor))
         ch = children(s.cursor)
-        isempty(ch) || return instance(PreOrderState, first(ch))
+        isemptychild(ch) || return instance(PreOrderState, first(ch))
     end
 
     csr = s.cursor
@@ -376,7 +376,7 @@ Base.iterate(ti::StatelessBFS) = (ti.root, [])
 function _descend_left(inds, next_node, level)
     while length(inds) ≠ level
         ch = children(next_node)
-        isempty(ch) && break
+        isemptychild(ch) && break
         push!(inds, 1)
         next_node = first(ch)
     end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -208,7 +208,7 @@ function print_tree(printnode::Function, io::IO, node;
     c = children(node)
 
     # No children?
-    ischildenempty(c) && return
+    ischildrenempty(c) && return
 
     # Reached max depth?
     if depth ≥ maxdepth

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -208,7 +208,7 @@ function print_tree(printnode::Function, io::IO, node;
     c = children(node)
 
     # No children?
-    isempty(c) && return
+    isemptychild(c) && return
 
     # Reached max depth?
     if depth ≥ maxdepth

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -208,7 +208,7 @@ function print_tree(printnode::Function, io::IO, node;
     c = children(node)
 
     # No children?
-    isemptychild(c) && return
+    ischildenempty(c) && return
 
     # Reached max depth?
     if depth ≥ maxdepth


### PR DESCRIPTION
During some profileing I noticed the `isempty` test on children were causing a call to `next` then `iterate`

This remedies that buy replacing any call to `isempty(children(node))` with effectively `ischildrenempty(children(node))` which for the most part is just checking for the interface definition of empty which is an empty typle.

The major culprit of the problem was `isempty(children(TreeCursor))`

Benchmark code:
```julia
using AbstractTrees
using BenchmarkTools

function randomArrayBinaryTreeNode(leaf_probabilty=0.5; max_depth=10, inds_range=1:2^10, inds_count_range=2:10)
    if rand() <= leaf_probabilty || max_depth == 0
        return rand(inds_range, rand(inds_count_range))
    else
        l = randomArrayBinaryTreeNode(leaf_probabilty; max_depth=max_depth - 1, inds_range, inds_count_range)
        r = randomArrayBinaryTreeNode(leaf_probabilty; max_depth=max_depth - 1, inds_range, inds_count_range)
        return [l,r]
    end
end


# This makes sure that the random tree is not ranom in size 
# random_tree = randomIndicesBinaryTreeNode(0.0, max_depth=10, inds_count_range=2:2)
random_tree = randomArrayBinaryTreeNode(0.0, max_depth=10, inds_count_range=2:2)

function test_function(tree, num=1)
    n = 0
    for m = 1:num
        n = 0
        for obj in PostOrderDFS(tree)
            n += 1
        end
    end
    return n
end
##
@benchmark treebreadth($random_tree)
##
@benchmark treeheight($random_tree)
##
@benchmark test_function($random_tree,2)
##
@benchmark count(_->true, Leaves($random_tree))
##
@benchmark count(_->true, PreOrderDFS($random_tree))
``` 

master benchmarks:
```julia
BenchmarkTools.Trial: 10000 samples with 5 evaluations.
 Range (min … max):  6.730 μs … 44.979 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.029 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.343 μs ±  1.078 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅▇▃█▆▄▃▂▂▂  ▁   ▃▁ ▂▅▂ ▁▃                                  ▂
  █████████████▇▅███████████▆▆▆▄▅▄▃▄▆▅▆▆▇▆▅▆▅▅▅▅▃▄▁▄▅▄▅▄▅▄▅▄ █
  6.73 μs      Histogram: log(frequency) by time     11.3 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

BenchmarkTools.Trial: 10000 samples with 4 evaluations.
 Range (min … max):  7.375 μs … 54.647 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.550 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   8.150 μs ±  1.868 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▅▄▃▃▂▃▂ ▅▂▅▅▁▃▃▁                                          ▂
  ██████████████████▇▆▄▅▅▅▅▅▅▅▄▄▅▃▅▅▃▆▅▄▄▅▅▄▃▃▃▄▅▃▄▄▄▄▁▃▄▅▄▃ █
  7.38 μs      Histogram: log(frequency) by time     14.4 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

BenchmarkTools.Trial: 844 samples with 1 evaluation.
 Range (min … max):  4.707 ms … 14.161 ms  ┊ GC (min … max): 0.00% … 40.54%
 Time  (median):     5.379 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.916 ms ±  1.376 ms  ┊ GC (mean ± σ):  1.48% ±  5.94%

  ▇█▅                                                         
  ███▆▅▆▅▄▆▄▆▃▃▄▄▄▄▄▄▄▄▄▃▄▃▃▃▃▃▃▃▃▂▃▃▃▂▃▂▂▂▂▂▂▁▁▂▁▁▂▂▂▂▁▂▁▁▂ ▃
  4.71 ms        Histogram: frequency by time        11.1 ms <

 Memory estimate: 1.04 MiB, allocs estimate: 45882.

BenchmarkTools.Trial: 1592 samples with 1 evaluation.
 Range (min … max):  2.596 ms …   9.547 ms  ┊ GC (min … max): 0.00% … 59.26%
 Time  (median):     3.120 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.134 ms ± 587.732 μs  ┊ GC (mean ± σ):  1.02% ±  4.86%

    █          ▂                                               
  ▅▃█▅▄▃▄▃▃▃▄▄▆█▅▄▄▄▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▂▂▁▂▁▂▂▁▁▁▂▁▁▁▁▁▂▂ ▃
  2.6 ms          Histogram: frequency by time        5.34 ms <

 Memory estimate: 359.48 KiB, allocs estimate: 13793.

BenchmarkTools.Trial: 1319 samples with 1 evaluation.
 Range (min … max):  2.835 ms …  17.063 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.660 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.779 ms ± 973.802 μs  ┊ GC (mean ± σ):  1.19% ± 5.42%

  ▁█     ▂                                                     
  ██▆▅▅▅▄█▆▆▆█▇▆▇█▆▅▄▃▃▃▃▃▃▂▃▂▂▂▂▂▂▂▂▁▂▂▂▂▁▂▂▂▁▁▁▁▁▁▁▂▂▂▂▁▁▁▂ ▃
  2.84 ms         Histogram: frequency by time        7.88 ms <

 Memory estimate: 519.31 KiB, allocs estimate: 21976.

```

PR benchmarks
```julia
BenchmarkTools.Trial: 10000 samples with 5 evaluations.
 Range (min … max):  6.710 μs … 30.438 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.792 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.218 μs ±  1.152 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▃▆▂▁ ▁    ▂  ▅  ▃                                         ▁
  ███████▇▇▇▆███████▇▇▆▆▄▄▅▆▇▇▆▆▅▅▅▅▃▄▄▅▄▃▄▃▃▃▃▁▁▃▄▁▄▄▅▃▃▃▁▃ █
  6.71 μs      Histogram: log(frequency) by time       13 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

BenchmarkTools.Trial: 10000 samples with 4 evaluations.
 Range (min … max):  7.138 μs … 33.505 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.444 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.783 μs ±  1.066 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅█▆▃▆▆▆▂▁          ▁▄▂  ▅▅▁ ▂▄▂                            ▂
  ██████████▇▇█▆▆▇▇▄▄████████████▇▇▆▆▆▅▅▅▅▄▁▃▃▁▄▄▃▃▃▅▆▅▄▄▄▄▄ █
  7.14 μs      Histogram: log(frequency) by time     11.2 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

BenchmarkTools.Trial: 996 samples with 1 evaluation.
 Range (min … max):  4.614 ms …  10.041 ms  ┊ GC (min … max): 0.00% … 36.65%
 Time  (median):     4.803 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.016 ms ± 626.262 μs  ┊ GC (mean ± σ):  1.53% ±  6.02%

  █▄▁▄                                                         
  ████▇▄▄▄▄▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▁▁▁▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂ ▃
  4.61 ms         Histogram: frequency by time        8.14 ms <

 Memory estimate: 1.05 MiB, allocs estimate: 46092.

BenchmarkTools.Trial: 1825 samples with 1 evaluation.
 Range (min … max):  2.536 ms …   6.763 ms  ┊ GC (min … max): 0.00% … 52.58%
 Time  (median):     2.646 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.735 ms ± 389.647 μs  ┊ GC (mean ± σ):  1.03% ±  5.00%

  ▄█▅▅▇▅▃▂▂▁▂▁▁▁▁▁  ▁  ▁                                      ▁
  ████████████████████▇███▇▇▇▇▆▅▆▅▅▆▄▆▅▄▄▄▁▁▁▁▁▁▄▁▁▄▁▁▁▅▄▁▁▁▄ █
  2.54 ms      Histogram: log(frequency) by time      4.09 ms <

 Memory estimate: 359.95 KiB, allocs estimate: 13823.

BenchmarkTools.Trial: 1600 samples with 1 evaluation.
 Range (min … max):  2.853 ms …   7.947 ms  ┊ GC (min … max): 0.00% … 52.53%
 Time  (median):     2.979 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.122 ms ± 460.504 μs  ┊ GC (mean ± σ):  1.24% ±  5.59%

  █▂▅                                                          
  ███▄▄▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▁▂▂▁▂▁▁▂▂▂▁▂▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂ ▃
  2.85 ms         Histogram: frequency by time        6.27 ms <

 Memory estimate: 519.78 KiB, allocs estimate: 22006.
```