### PR TITLE
Increase customization in `print_tree`

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,7 +1,7 @@
 """
-    print_tree(tree; kwargs...)
-    print_tree(io::IO, tree; kwargs...)
-    print_tree(f::Function, io::IO, tree; kwargs...)
+    print_tree(tree; kw...)
+    print_tree(io::IO, tree; kw...)
+    print_tree(f::Function, io::IO, tree; kw...)
 
 Print a text representation of `tree` to the given `io` object.
 
@@ -82,7 +82,7 @@ Print a compact representation of a single node.  By default, this prints `nodev
 **OPTIONAL**: This can be extended for custom types and controls how nodes are shown
 in [`print_tree`](@ref).
 """
-printnode(io::IO, node) = show(IOContext(io, :compact => true, :limit => true), nodevalue(node))
+printnode(io::IO, node; kw...) = show(IOContext(io, :compact => true, :limit => true), nodevalue(node))
 
 
 """
@@ -192,10 +192,11 @@ function print_tree(printnode::Function, io::IO, node;
                     printkeys::Union{Bool,Nothing}=nothing,
                     depth::Integer=0,
                     prefix::AbstractString="",
+                    kw...
                    )
     # Get node representation as string
     buf = IOBuffer()
-    printnode(IOContext(buf, io), node)
+    printnode(IOContext(buf, io), node; kw...)
     str = String(take!(buf))
 
     # Copy buffer to output, prepending prefix to each line

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -282,7 +282,7 @@ Get the string result of calling [`print_tree`](@ref) with the supplied argument
 The `context` argument works as it does in `Base.repr`.
 """
 repr_tree(tree; context=nothing, kw...) = repr_tree(printnode, print_child_key, tree; context=nothing, kw...)
-function repr_tree(f, g, tree; context=nothing, kw...)
+function repr_tree(f::Function, g::Function, tree; context=nothing, kw...)
     buf = IOBuffer()
     io = context === nothing ? buf : IOContext(buf, context)
     print_tree(f, g, io, tree; kw...)

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -190,14 +190,10 @@ end
                    """)
 
     # Test printnode override
-    str = repr_tree(tree) do io, s
-        if s isa BoxNode
-            print(io, s.s)
-        else
-            AbstractTrees.printnode(io, s)
-        end
-    end
+    _f(io, s) = s isa BoxNode ? print(io, s.s) : AbstractTrees.printnode(io, s)
+    _g(io, k) = AbstractTrees.print_child_key(io, k)
 
+    str = repr_tree(_f, _g, tree) 
     @test endswith(str, """
                    ├─ "foo"
                    ├─ bar


### PR DESCRIPTION
The purpose of this PR is to expand `print_tree` to increase the opportunity for customized tree printer for users. 

The use case that originated this is this PR https://github.com/FedeClaudi/Term.jl/pull/187 in `Term.jl` where I use `print_tree` to create `Tree` visualizations. To that end, I call `print_tree` with a custom `printnode` function. However two additional features would help:
1. pass keyword arguments to the custom `printnode` function to carry over some contextual information for styled printing.
2. also allow for the use of custom `print_child_key` function to facilitate styling of keys too.

---
This PR facilitates further work in https://github.com/FedeClaudi/Term.jl/pull/187 and closes https://github.com/JuliaCollections/AbstractTrees.jl/issues/93 since the integration would be complete. Might also offer an opportunity to address https://github.com/JuliaCollections/AbstractTrees.jl/issues/121