### PR TITLE
Undo breaking `print_tree` change

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -268,7 +268,7 @@ function print_tree(printnode::Function, print_child_key::Function, io::IO, node
 
         print_tree(printnode, print_child_key, io, child;
                    maxdepth=maxdepth, indicate_truncation=indicate_truncation, charset=charset,
-                   printkeys=printkeys, depth=depth+1, prefix=child_prefix, printnode_kw
+                   printkeys=printkeys, depth=depth+1, prefix=child_prefix, printnode_kw=printnode_kw,
                   )
     end
 end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -198,16 +198,16 @@ end
         end
     end
     @test endswith(str_do, """
-    ├─ "foo"
-    ├─ bar
-    │  ├─ 1
-    │  ├─ 2:4
-    │  │  ├─ 2
-    │  │  ├─ 3
-    │  │  └─ 4
-    │  └─ 5
-    └─ "baz"
-    """)
+                   ├─ "foo"
+                   ├─ bar
+                   │  ├─ 1
+                   │  ├─ 2:4
+                   │  │  ├─ 2
+                   │  │  ├─ 3
+                   │  │  └─ 4
+                   │  └─ 5
+                   └─ "baz"
+                   """)
 
     # Test printnode and print_child_key override 
     _f(io, s) = s isa BoxNode ? print(io, s.s) : AbstractTrees.printnode(io, s)

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -189,20 +189,39 @@ end
                    └─ "baz"
                    """)
 
-    # Test printnode override
-    _f(io, s) = s isa BoxNode ? print(io, s.s) : AbstractTrees.printnode(io, s)
-    _g(io, k) = AbstractTrees.print_child_key(io, k)
+    # Test printnode override do block syntax
+    str_do = repr_tree(tree) do io, s
+        if s isa BoxNode
+            print(io, s.s)
+        else
+            AbstractTrees.printnode(io, s)
+        end
+    end
+    @test endswith(str_do, """
+    ├─ "foo"
+    ├─ bar
+    │  ├─ 1
+    │  ├─ 2:4
+    │  │  ├─ 2
+    │  │  ├─ 3
+    │  │  └─ 4
+    │  └─ 5
+    └─ "baz"
+    """)
 
-    str = repr_tree(_f, _g, tree) 
+    # Test printnode and print_child_key override 
+    _f(io, s) = s isa BoxNode ? print(io, s.s) : AbstractTrees.printnode(io, s)
+    _g(io, k) = AbstractTrees.print_child_key(io, k-1)
+    str = repr_tree(_f, _g, tree; printkeys=true) 
     @test endswith(str, """
-                   ├─ "foo"
-                   ├─ bar
-                   │  ├─ 1
-                   │  ├─ 2:4
-                   │  │  ├─ 2
-                   │  │  ├─ 3
-                   │  │  └─ 4
-                   │  └─ 5
-                   └─ "baz"
+                   ├─ 0 ⇒ "foo"
+                   ├─ 1 ⇒ bar
+                   │      ├─ 0 ⇒ 1
+                   │      ├─ 1 ⇒ 2:4
+                   │      │      ├─ 0 ⇒ 2
+                   │      │      ├─ 1 ⇒ 3
+                   │      │      └─ 2 ⇒ 4
+                   │      └─ 2 ⇒ 5
+                   └─ 2 ⇒ "baz"
                    """)
 end


### PR DESCRIPTION
#124 removed the public `print_tree(f::Function, io::IO, tree; kw...)` method. This PR adds it back.

#124 also passed any extra unused keyword arguments to only the first call the `printnode`.
Also, this means that in the future if a new keyword arg is added to the `print_tree` definition in `AbstractTrees` it could be a breaking change, as that keyword arg will no longer be passed to `printnode`.

Because of this, instead of passing the extra unused keyword args of `print_tree` to `printnode`, I created a new keyword `printnode_kw` that will get splatted as the keyword args for each call to `printnode`.