### PR TITLE
fix print_child_key with color

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -258,11 +258,11 @@ function print_tree(printnode::Function, print_child_key::Function, io::IO, node
 
         # Print key
         if this_printkeys
-            print_child_key(IOContext(buf, io), child_key)
+            print_child_key(io, child_key)
+            print(io, charset.pair)
+
+            print_child_key(IOContext(IOContext(buf, io), :color=>false), child_key)
             key_str = String(take!(buf))
-
-            print(io, key_str, charset.pair)
-
             child_prefix *= " " ^ (textwidth(key_str) + textwidth(charset.pair))
         end
 


### PR DESCRIPTION
`textwidth` does not escape ASCII escape chars, which as a result gives wrong estimation of the text width, this might need to be fixed upstream (or use a more accurate function), but this PR is a workaround to this.