### PR TITLE
Add `print*` functions to documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -184,6 +184,8 @@ treebreadth
 treeheight
 descendleft
 getroot
+printtree
+printnode
 ```
 
 ## Example Implementations


### PR DESCRIPTION
Having to jump into the source code to find the latest docstrings is a bit of a pain. This reintroduces the functions to the main page of the package's published documentation.

Closes #121.