### PR TITLE
Update `Documenter`, fix errors/warnings

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -10,7 +10,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.26"
+Documenter = "1.4"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,6 +85,7 @@ Types with the `IndexedChildren` trait *must* return an indexable object from `c
 NodeType
 NodeTypeUnknown
 HasNodeType
+nodetype
 ```
 
 Providing the `HasNodeType` trait will guarantee that all nodes connected to the node must be of the
@@ -180,12 +181,18 @@ ischild
 isroot
 intree
 isdescendant
+treesize
 treebreadth
 treeheight
 descendleft
 getroot
-printtree
+print_tree
 printnode
+print_child_key
+TreeCharSet
+shouldprintkeys
+repr_tree
+repr_node
 ```
 
 ## Example Implementations

--- a/docs/src/iteration.md
+++ b/docs/src/iteration.md
@@ -34,6 +34,7 @@ PostOrderDFS
 Leaves
 Siblings
 StatelessBFS
+MapNode
 treemap
 ```
 
@@ -56,4 +57,6 @@ instance
 initial
 next
 statetype
+ascend
+descend
 ```

--- a/src/AbstractTrees.jl
+++ b/src/AbstractTrees.jl
@@ -1,11 +1,3 @@
-"""
-    AbstractTrees
-
-This package is intended to provide an abstract interface for working
-with tree structures.
-Though the package itself is not particularly sophisticated, it defines
-the interface that can be used by other packages to talk about trees.
-"""
 module AbstractTrees
 
 using Base: HasLength, SizeUnknown, HasEltype, EltypeUnknown

--- a/src/base.jl
+++ b/src/base.jl
@@ -2,7 +2,7 @@
 """
     nodevalue(node)
 
-Get the value associated with a node in a tree.  This removes wrappers such as [`Indexed`](@ref) or [`TreeCursor`](@ref)s.
+Get the value associated with a node in a tree.  This removes wrappers such as [`IndexNode`](@ref) or [`TreeCursor`](@ref)s.
 
 By default, this function is the identity.
 

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -36,7 +36,7 @@ Obtain the next [`IteratorState`](@ref) after the current one.  If `s` is the fi
 `nothing`.
 
 This provides an alternative iteration protocol which only uses the states directly as opposed to
-[`Base.iterate`](@ref) which takes an iterator object and the current state as separate arguments.
+`Base.iterate` which takes an iterator object and the current state as separate arguments.
 """
 function next end
 

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -19,7 +19,7 @@ signature `g(io::IO, key;)`.
   truncated nodes.
 * `charset::TreeCharSet` - [`TreeCharSet`](@ref) to use to print branches.
 * `printkeys::Union{Bool, Nothing}` - Whether to print keys of child nodes (using
-  `pairs(children(node))`). A value of `nothing` uses [`printkeys_default`](@ref) do decide the
+  `pairs(children(node))`). A value of `nothing` uses [`shouldprintkeys`](@ref) to decide the
   behavior on a node-by-node basis.
 * `printnode_kw = (;)` - keyword arguments to forward to `f`. 
 


### PR DESCRIPTION
#145 included a typo. This PR addresses that, as well as several errors that were slipping by as they were treated as warnings. Bumping to the latest version of `Documenter` treats these as errors by default, so they won't be missed in the future.

The docstring is removed for the entire `AbstractTrees` module because `Documenter` errors if that docstring is not placed somewhere in the docs. As the same info (and more) is covered on the index page of the docs, I assumed it would be safe to remove it from the module file.

My apologies for missing the typo in #145. Everything builds locally for me—hoping this resolves these documentation issues in their entirety.